### PR TITLE
Move over K"inert"

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -19,6 +19,8 @@ function _register_kinds()
             "Value"
             # A (quoted) `Symbol`
             "Symbol"
+            # QuoteNode; not quasiquote
+            "inert"
             # Compiler metadata hints
             "meta"
             # TODO: Use `meta` for inbounds and loopinfo etc?


### PR DESCRIPTION
JuliaSyntax does not generate this kind, so I'm moving it over here. See https://github.com/JuliaLang/JuliaSyntax.jl/pull/561/.