### PR TITLE
add precompilation statements to improve first-time-to-lower latency

### DIFF
--- a/src/JuliaLowering.jl
+++ b/src/JuliaLowering.jl
@@ -37,4 +37,6 @@ function __init__()
     _register_kinds()
 end
 
+_include("precompile.jl")
+
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,27 @@
+# exercise the whole lowering pipeline
+if Base.get_bool_env("JULIA_LOWERING_PRECOMPILE", true)
+    thunks = String[
+        """
+        function foo(xxx, yyy)
+            @nospecialize xxx yyy
+            return Pair{Any,Any}(typeof(xxx), typeof(yyy))
+        end
+        """
+
+        """
+        struct Foo
+            x::Int
+            Foo(x::Int) = new(x)
+            Foo() = new()
+        end
+        """
+    ]
+    for thunk in thunks
+        stream = JuliaSyntax.ParseStream(thunk)
+        JuliaSyntax.parse!(stream; rule=:all)
+        st0 = JuliaSyntax.build_tree(SyntaxTree, stream; filename=@__FILE__)
+        lwrst = lower(@__MODULE__, st0)
+        lwr = to_lowered_expr(@__MODULE__, lwrst)
+        @assert Meta.isexpr(lwr, :thunk) && only(lwr.args) isa Core.CodeInfo
+    end
+end


### PR DESCRIPTION
Exercises the complete lowering pipeline during precompilation with a sample code thunks to create method and type definitions.

This precompilation is enabled by default but can be disabled by setting the `JULIA_LOWERING_PRECOMPILE` environment variable to false-cy, which may be useful during development.

Ideally we'd like to use Preferences.jl for this configuration, but my understanding is that JuliaLowering aims to be self-contained and should not add dependencies other than JuliaSyntax.