### PR TITLE
make `showprov()` able to take optional keyword arguments for `highlight()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This work is intended to
 * Bring precise code provenance to Julia's lowered form (and eventually
   downstream in type inference, stack traces, etc). This has many benefits
     - Talk to users precisely about their code via character-precise error and
-      diagnostic messages from lowering 
+      diagnostic messages from lowering
     - Greatly simplify the implementation of critical tools like Revise.jl
       which rely on analyzing how the user's source maps to the compiler's data
       structures
@@ -109,10 +109,10 @@ For example when parsing a source file we have
 ```julia
 julia> ex = parsestmt(SyntaxTree, "a + b", filename="foo.jl")
 SyntaxTree with attributes kind,value,name_val,syntax_flags,source
-[call-i]                                │ 
-  a                                     │ 
-  +                                     │ 
-  b                                     │ 
+[call-i]                                │
+  a                                     │
+  +                                     │
+  b                                     │
 
 julia> ex[3].source
 a + b
@@ -157,9 +157,9 @@ The tree which arises from macro expanding this is pretty simple:
 ```julia
 julia> expanded = JuliaLowering.macroexpand(Main, parsestmt(SyntaxTree, "M.@outer()"))
 SyntaxTree with attributes scope_layer,kind,value,var_id,name_val,syntax_flags,source
-[tuple-p]                               │ 
-  1                                     │ 
-  2                                     │ 
+[tuple-p]                               │
+  1                                     │
+  2                                     │
 ```
 
 but the provenance information recorded for the second element `2` of this
@@ -777,7 +777,7 @@ The final lowered IR is expressed as `CodeInfo` objects which are a sequence of
 * Restricted forms of `Expr` (with semantics different from surface syntax,
   even for the same `head`! for example the arguments to `Expr(:call)` in IR
   must be "simple" and aren't evaluated in order)
-* `Core.SlotNumber` 
+* `Core.SlotNumber`
 * Other special forms from `Core` like `Core.ReturnNode`, `Core.EnterNode`, etc.
 * `Core.SSAValue`, indexing any value generated from a statement in the `code`
   array.
@@ -857,7 +857,7 @@ Pros:
 - Replaces more Expr usage
 - Replaces a whole pile of C code with significantly less Julia code
 - Lowering output becomes more consistently imperative
-Cons: 
+Cons:
 - Lots more code to write
 - May need to invent intermediate data structures to replace `Expr`
 - Bootstrap?
@@ -895,4 +895,3 @@ Some differences which makes Racket's macro expander different from Julia:
   expand macros; the "pass system". Julia just executes all top level
   statements in order when precompiling a package.
 * As a lisp, Racket's surface syntax is dramatically simpler and more uniform
-

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,17 +39,19 @@ function _show_provtree(io::IO, prov, indent)
     printstyled(io, "@ $fn:$line\n", color=:light_black)
 end
 
-function showprov(io::IO, exs::AbstractVector)
+function showprov(io::IO, exs::AbstractVector; note=nothing, highlight_kwargs...)
     for (i,ex) in enumerate(Iterators.reverse(exs))
         sr = sourceref(ex)
         if i > 1
             print(io, "\n\n")
         end
         k = kind(ex)
-        note = i > 1 && k == K"macrocall"  ? "in macro expansion" :
-               i > 1 && k == K"$"          ? "interpolated here"  :
-               "in source"
-        highlight(io, sr, note=note)
+        if isnothing(note)
+            note = i > 1 && k == K"macrocall"  ? "in macro expansion" :
+                   i > 1 && k == K"$"          ? "interpolated here"  :
+                   "in source"
+        end
+        highlight(io, sr; note=note, highlight_kwargs...)
 
         line, _ = source_location(sr)
         locstr = "$(filename(sr)):$line"
@@ -57,11 +59,11 @@ function showprov(io::IO, exs::AbstractVector)
     end
 end
 
-function showprov(io::IO, ex::SyntaxTree; tree=false)
+function showprov(io::IO, ex::SyntaxTree; tree::Bool=false, showprov_kwargs...)
     if tree
         _show_provtree(io, ex, "")
     else
-        showprov(io, flattened_provenance(ex))
+        showprov(io, flattened_provenance(ex); showprov_kwargs...)
     end
 end
 
@@ -165,4 +167,3 @@ function _print_ir(io::IO, ex, indent)
         end
     end
 end
-

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,23 +39,26 @@ function _show_provtree(io::IO, prov, indent)
     printstyled(io, "@ $fn:$line\n", color=:light_black)
 end
 
-function showprov(io::IO, exs::AbstractVector; note=nothing, highlight_kwargs...)
+function showprov(io::IO, exs::AbstractVector;
+                  note=nothing, include_location::Bool=true, highlight_kwargs...)
     for (i,ex) in enumerate(Iterators.reverse(exs))
         sr = sourceref(ex)
         if i > 1
             print(io, "\n\n")
         end
         k = kind(ex)
-        if isnothing(note)
+        if isnothing(note) # use provided `note` otherwise
             note = i > 1 && k == K"macrocall"  ? "in macro expansion" :
                    i > 1 && k == K"$"          ? "interpolated here"  :
                    "in source"
         end
         highlight(io, sr; note=note, highlight_kwargs...)
 
-        line, _ = source_location(sr)
-        locstr = "$(filename(sr)):$line"
-        JuliaSyntax._printstyled(io, "\n# @ $locstr", fgcolor=:light_black)
+        if include_location
+            line, _ = source_location(sr)
+            locstr = "$(filename(sr)):$line"
+            JuliaSyntax._printstyled(io, "\n# @ $locstr", fgcolor=:light_black)
+        end
     end
 end
 


### PR DESCRIPTION
So that user of `showprov` can tweak options of `highlight`, e.g, `color` and `context_lines_before`.

Also adds `include_location::Bool=true` option to configure whether to include location information after showing provenance.