### PR TITLE
Add error handling for macro name resolution

### DIFF
--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -127,7 +127,7 @@ function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex::Syn
     try
         eval(mod, expr_form)
     catch
-        throw(MacroExpansionError(mctx, ex, "Error evaluating macro name", :all))
+        throw(MacroExpansionError(mctx, ex, "Macro not found", :all))
     end
 end
 

--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -113,7 +113,7 @@ function Base.showerror(io::IO, exc::MacroExpansionError)
     highlight(io, src.file, byterange, note=exc.msg)
 end
 
-function eval_macro_name(ctx::MacroExpansionContext, ex::SyntaxTree)
+function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex::SyntaxTree)
     # `ex1` might contain a nontrivial mix of scope layers so we can't just
     # `eval()` it, as it's already been partially lowered by this point.
     # Instead, we repeat the latter parts of `lower()` here.
@@ -124,21 +124,25 @@ function eval_macro_name(ctx::MacroExpansionContext, ex::SyntaxTree)
     ctx5, ex5 = linearize_ir(ctx4, ex4)
     mod = ctx.current_layer.mod
     expr_form = to_lowered_expr(mod, ex5)
-    eval(mod, expr_form)
+    try
+        eval(mod, expr_form)
+    catch
+        throw(MacroExpansionError(mctx, ex, "Error evaluating macro name", :all))
+    end
 end
 
 function expand_macro(ctx::MacroExpansionContext, ex::SyntaxTree)
     @assert kind(ex) == K"macrocall"
 
     macname = ex[1]
-    macfunc = eval_macro_name(ctx, macname)
+    mctx = MacroContext(ctx.graph, ex, ctx.current_layer)
+    macfunc = eval_macro_name(ctx, mctx, macname)
     # Macro call arguments may be either
     # * Unprocessed by the macro expansion pass
     # * Previously processed, but spliced into a further macro call emitted by
     #   a macro expansion.
     # In either case, we need to set any unset scope layers before passing the
     # arguments to the macro call.
-    mctx = MacroContext(ctx.graph, ex, ctx.current_layer)
     macro_args = Any[mctx]
     for i in 2:numchildren(ex)
         push!(macro_args, set_scope_layer(ctx, ex[i], ctx.current_layer.id, false))

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -161,6 +161,15 @@ let (err, st) = try
     @test any(sf->sf.func===Symbol("@m_throw"), st)
 end
 
+let res = try
+        JuliaLowering.include_string(test_mod, "_never_exist = @m_not_exist 42")
+    catch e
+        e
+    end
+    @test res isa JuliaLowering.MacroExpansionError
+    @test res.msg == "Error evaluating macro name"
+end
+
 include("ccall_demo.jl")
 @test JuliaLowering.include_string(CCall, "@ccall strlen(\"foo\"::Cstring)::Csize_t") == 3
 let (err, st) = try

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -167,7 +167,7 @@ let res = try
         e
     end
     @test res isa JuliaLowering.MacroExpansionError
-    @test res.msg == "Error evaluating macro name"
+    @test res.msg == "Macro not found"
 end
 
 include("ccall_demo.jl")

--- a/test/macros_ir.jl
+++ b/test/macros_ir.jl
@@ -125,3 +125,10 @@ function f()
 #─────┘ ── macro is only allowed in global scope
 end
 
+########################################
+# Error: Macros not found
+_never_exist = @m_not_exist 42
+#---------------------
+MacroExpansionError while expanding @m_not_exist in module Main.TestMod:
+_never_exist = @m_not_exist 42
+#               └─────────┘ ── Macro not found


### PR DESCRIPTION
Wrap `eval()` call in try-catch to throw `MacroExpansionError` when
macro name evaluation fails, providing clearer error messages for
undefined macro names.