### PR TITLE
Add inner `err` capture to `MacroExpansionError`

### DIFF
--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -78,12 +78,19 @@ struct MacroExpansionError <: Exception
     context::Union{Nothing,MacroContext}
     ex::SyntaxTree
     msg::String
+    "The source position relative to the node - may be `:begin` or `:end` or `:all`"
     position::Symbol
+    "Error that occurred inside the macro function call (note that this may not be defined)"
+    err
+    MacroExpansionError(
+        context::Union{Nothing,MacroContext}, ex::SyntaxTree, msg::AbstractString, position::Symbol
+    ) = new(context, ex, msg, position)
+    MacroExpansionError(
+        context::Union{Nothing,MacroContext}, ex::SyntaxTree, msg::AbstractString, position::Symbol,
+        @nospecialize err
+    ) = new(context, ex, msg, position, err)
 end
 
-"""
-`position` - the source position relative to the node - may be `:begin` or `:end` or `:all`
-"""
 function MacroExpansionError(ex::SyntaxTree, msg::AbstractString; position=:all)
     MacroExpansionError(nothing, ex, msg, position)
 end
@@ -126,8 +133,8 @@ function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex::Syn
     expr_form = to_lowered_expr(mod, ex5)
     try
         eval(mod, expr_form)
-    catch
-        throw(MacroExpansionError(mctx, ex, "Macro not found", :all))
+    catch err
+        throw(MacroExpansionError(mctx, ex, "Macro not found", :all, err))
     end
 end
 
@@ -152,14 +159,16 @@ function expand_macro(ctx::MacroExpansionContext, ex::SyntaxTree)
         # TODO: Allow invoking old-style macros for compat
         invokelatest(macfunc, macro_args...)
     catch exc
-        # TODO: Using rethrow() is kinda ugh. Is there a way to avoid it?
-        # NOTE: Although currently rethrow() is necessary to allow outside catchers to access full stacktrace information
         if exc isa MacroExpansionError
             # Add context to the error.
-            rethrow(MacroExpansionError(mctx, exc.ex, exc.msg, exc.position))
+            newexc = isdefined(exc, :err) ?
+                MacroExpansionError(mctx, exc.ex, exc.msg, exc.position, exc.err) :
+                MacroExpansionError(mctx, exc.ex, exc.msg, exc.position)
         else
-            rethrow(MacroExpansionError(mctx, ex, "Error expanding macro", :all))
+            newexc = MacroExpansionError(mctx, ex, "Error expanding macro", :all, exc)
         end
+        # TODO: We can delete this rethrow when we move to AST-based error propagation.
+        rethrow(newexc)
     end
 
     if expanded isa SyntaxTree

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -156,20 +156,20 @@ let (err, st) = try
         e, stacktrace(catch_backtrace())
     end
     @test err isa JuliaLowering.MacroExpansionError
-    @test isdefined(err, :err)
+    @test !isnothing(err.err)
     # Check that `catch_backtrace` can capture the stacktrace of the macro functions
     @test any(sf->sf.func===:f_throw, st)
     @test any(sf->sf.func===Symbol("@m_throw"), st)
 end
 
-let res = try
+let err = try
         JuliaLowering.include_string(test_mod, "_never_exist = @m_not_exist 42")
     catch e
         e
     end
-    @test res isa JuliaLowering.MacroExpansionError
-    @test res.msg == "Macro not found"
-    @test isdefined(res, :err) && res.err isa UndefVarError
+    @test err isa JuliaLowering.MacroExpansionError
+    @test err.msg == "Macro not found"
+    @test err.err isa UndefVarError
 end
 
 include("ccall_demo.jl")
@@ -181,7 +181,7 @@ let (err, st) = try
     end
     @test err isa JuliaLowering.MacroExpansionError
     @test err.msg == "Expected a return type annotation like `::T`"
-    @test !isdefined(err, :err)
+    @test isnothing(err.err)
     # Check that `catch_backtrace` can capture the stacktrace of the macro function
     @test any(sf->sf.func===:ccall_macro_parse, st)
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -156,6 +156,7 @@ let (err, st) = try
         e, stacktrace(catch_backtrace())
     end
     @test err isa JuliaLowering.MacroExpansionError
+    @test isdefined(err, :err)
     # Check that `catch_backtrace` can capture the stacktrace of the macro functions
     @test any(sf->sf.func===:f_throw, st)
     @test any(sf->sf.func===Symbol("@m_throw"), st)
@@ -168,6 +169,7 @@ let res = try
     end
     @test res isa JuliaLowering.MacroExpansionError
     @test res.msg == "Macro not found"
+    @test isdefined(res, :err) && res.err isa UndefVarError
 end
 
 include("ccall_demo.jl")
@@ -179,6 +181,7 @@ let (err, st) = try
     end
     @test err isa JuliaLowering.MacroExpansionError
     @test err.msg == "Expected a return type annotation like `::T`"
+    @test !isdefined(err, :err)
     # Check that `catch_backtrace` can capture the stacktrace of the macro function
     @test any(sf->sf.func===:ccall_macro_parse, st)
 end


### PR DESCRIPTION
Information about this inner exception is currently completely lost, so without capturing it, there is no way for outside catchers to access this information.