### PR TITLE
use `Base.IncludeInto` for `_include`

### DIFF
--- a/src/JuliaLowering.jl
+++ b/src/JuliaLowering.jl
@@ -4,7 +4,7 @@ baremodule JuliaLowering
 using Base
 # We define a separate _include() for use in this module to avoid mixing method
 # tables with the public `JuliaLowering.include()` API
-_include(path::AbstractString) = Base.include(JuliaLowering, path)
+const _include = Base.IncludeInto(JuliaLowering)
 using Core: eval
 
 using JuliaSyntax

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -1,4 +1,3 @@
-
 # The following kinds are used in intermediate forms by lowering but are not
 # part of the surface syntax
 function _register_kinds()


### PR DESCRIPTION
This does not change any behavior on JL side, but this is necessary to allow JET to analyze JL (although we still need to have [a JET-specific hack for `JS.register_kinds!`](https://github.com/JuliaLang/JuliaSyntax.jl/commit/b2066e3b3b990c00d140bfa388fb8fac2f29d053) to actually make JL actually analyzable by JET).