### PR TITLE
Fixes for opaque closure method lowering

### DIFF
--- a/test/closures.jl
+++ b/test/closures.jl
@@ -235,4 +235,10 @@ let
 end
 """) == (3,4,5)
 
+# opaque_closure_method internals
+method_ex = lower_str(test_mod, "Base.Experimental.@opaque x -> 2x").args[1].code[3]
+@test method_ex.head === :opaque_closure_method
+@test method_ex.args[1] === nothing
+@test method_ex.args[4] isa LineNumberNode
+
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -47,11 +47,8 @@ cf_float = JuliaLowering.include_string(test_mod, """
 @test @ccall($cf_float(2::Float64, 3::Float64)::Float64) == 32.0
 
 @testset "CodeInfo: has_image_globalref" begin
-    elower(mod, s) = JuliaLowering.to_lowered_expr(
-        mod, JuliaLowering.lower(
-            mod, parsestmt(JuliaLowering.SyntaxTree, s)))
-    @test elower(test_mod, "x + y").args[1].has_image_globalref === false
-    @test elower(Main, "x + y").args[1].has_image_globalref === true
+    @test lower_str(test_mod, "x + y").args[1].has_image_globalref === false
+    @test lower_str(Main, "x + y").args[1].has_image_globalref === true
 end
 
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -262,6 +262,11 @@ function watch_ir_tests(dir, delay=0.5)
     end
 end
 
+function lower_str(mod, s)
+    ex = parsestmt(JuliaLowering.SyntaxTree, s)
+    return JuliaLowering.to_lowered_expr(mod, JuliaLowering.lower(mod, ex))
+end
+
 # See Julia Base tests in "test/docs.jl"
 function docstrings_equal(d1, d2; debug=true)
     io1 = IOBuffer()


### PR DESCRIPTION
opaque_closure_method has special non-evaluated semantics for its argument list, so we need some special non-quoted conversion here for the functionloc argument and the name argument when it's set to the global ref Core.nothing.

To fix the globalref, I've chosen to translate `"core"::K"nothing"` into a literal `nothing` in general - this is consistent with how ast.c translates the special flisp `(null)` form.

Fix #30