### PR TITLE
Fix handling lower bound in type parameter

### DIFF
--- a/src/desugaring.jl
+++ b/src/desugaring.jl
@@ -3266,7 +3266,7 @@ function analyze_typevar(ctx, ex)
         (ex[1], nothing, ex[2])
     elseif k == K">:" && numchildren(ex) == 2
         kind(ex[2]) == K"Identifier" || throw(LoweringError(ex[2], "expected type name"))
-        (ex[2], ex[1], nothing)
+        (ex[1], ex[2], nothing)
     else
         throw(LoweringError(ex, "expected type name or type bounds"))
     end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -204,6 +204,27 @@ end
 
     @test JuliaLowering.include_string(test_mod, """
     begin
+        function f_def_typevar_with_lowerbound(x::T) where {T>:Int}
+            x
+        end
+
+        (f_def_typevar_with_lowerbound(1), f_def_typevar_with_lowerbound(1.0))
+    end
+    """) == (1, 1.0)
+
+    # throws "UndefVarError: `T` not defined in static parameter matching"
+    @test_throws UndefVarError JuliaLowering.include_string(test_mod, """
+    begin
+        function f_def_ret_typevar_with_lowerbound(x::T) where {T>:Int}
+            T
+        end
+
+        f_def_ret_typevar_with_lowerbound(1.0)
+    end
+    """)
+
+    @test JuliaLowering.include_string(test_mod, """
+    begin
         function f_def_slurp(x=1, ys...)
             (x, ys)
         end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -204,24 +204,11 @@ end
 
     @test JuliaLowering.include_string(test_mod, """
     begin
-        function f_def_typevar_with_lowerbound(x::T) where {T>:Int}
-            x
-        end
-
+        f_def_typevar_with_lowerbound(x::T) where {T>:Int} =
+            (x, @isdefined(T))
         (f_def_typevar_with_lowerbound(1), f_def_typevar_with_lowerbound(1.0))
     end
-    """) == (1, 1.0)
-
-    # throws "UndefVarError: `T` not defined in static parameter matching"
-    @test_throws UndefVarError JuliaLowering.include_string(test_mod, """
-    begin
-        function f_def_ret_typevar_with_lowerbound(x::T) where {T>:Int}
-            T
-        end
-
-        f_def_ret_typevar_with_lowerbound(1.0)
-    end
-    """)
+    """) == ((1, true), (1.0, false))
 
     @test JuliaLowering.include_string(test_mod, """
     begin

--- a/test/functions_ir.jl
+++ b/test/functions_ir.jl
@@ -200,6 +200,34 @@ end
 19  (return %₁₈)
 
 ########################################
+# Static parameter with lower bound
+function f(::S{T}) where T >: X
+    T
+end
+#---------------------
+1   (method TestMod.f)
+2   latestworld
+3   TestMod.X
+4   (= slot₁/T (call core.TypeVar :T %₃ core.Any))
+5   TestMod.f
+6   (call core.Typeof %₅)
+7   TestMod.S
+8   slot₁/T
+9   (call core.apply_type %₇ %₈)
+10  (call core.svec %₆ %₉)
+11  slot₁/T
+12  (call core.svec %₁₁)
+13  SourceLocation::1:10
+14  (call core.svec %₁₀ %₁₂ %₁₃)
+15  --- method core.nothing %₁₄
+    slots: [slot₁/#self#(!read) slot₂/_(!read)]
+    1   static_parameter₁
+    2   (return %₁)
+16  latestworld
+17  TestMod.f
+18  (return %₁₇)
+
+########################################
 # Static parameter which is used only in the bounds of another static parameter
 # See https://github.com/JuliaLang/julia/issues/49275
 function f(x, y::S) where {T, S<:AbstractVector{T}}

--- a/test/typedefs_ir.jl
+++ b/test/typedefs_ir.jl
@@ -25,10 +25,10 @@ A where X <: UB
 # where expression with lower bound
 A where X >: LB
 #---------------------
-1   TestMod.X
-2   (call core.TypeVar :LB %₁ core.Any)
-3   (= slot₁/LB %₂)
-4   slot₁/LB
+1   TestMod.LB
+2   (call core.TypeVar :X %₁ core.Any)
+3   (= slot₁/X %₂)
+4   slot₁/X
 5   TestMod.A
 6   (call core.UnionAll %₄ %₅)
 7   (return %₆)


### PR DESCRIPTION
The following is a valid Julia method definition, 

```julia
f(x::T) where T >: Int = 0
```

but it results in an error with the latest version of Julia and JuliaLowering.

```
LoweringError:
f(x::T) where T >: Int = x
#                  └─┘ ── Method definition declares type variable but does not use it in the type of any function parameter
```

Upon inspecting the analyze routine for `where`, I found an issue in the handling of lower bounds as well as an error in the corresponding test case, so I have fixed it.

Current testcase:

https://github.com/c42f/JuliaLowering.jl/blob/7badaaa56443bacd67239802ada00f817565761f/test/typedefs_ir.jl#L24-L35

Based on the following output:

```julia
julia> VERSION
v"1.13.0-DEV.971"

julia> Meta.lower(Main, :(A where X >: LB))
:($(Expr(:thunk, CodeInfo(
1 ─ %1 = Main.LB
│   %2 =   dynamic Core.TypeVar(:X, %1, Core.Any)
│        X = %2
│   %4 = X
│   %5 = Main.A
│   %6 =   dynamic Core.UnionAll(%4, %5)
└──      return %6
))))
```

it should instead look like this:

```
1   TestMod.LB
2   (call core.TypeVar :X %₁ core.Any)
3   (= slot₁/X %₂)
4   slot₁/X
5   TestMod.A
6   (call core.UnionAll %₄ %₅)
7   (return %₆)
```