### PR TITLE
Expand `import/using` to newer Base runtime calls

### DIFF
--- a/src/desugaring.jl
+++ b/src/desugaring.jl
@@ -4098,7 +4098,9 @@ end
 #-------------------------------------------------------------------------------
 # Expand import / using / export
 
-function _append_importpath(ctx, path_spec, path)
+function expand_importpath(path)
+    @chk kind(path) == K"importpath"
+    path_spec = Expr(:.)
     prev_was_dot = true
     for component in children(path)
         k = kind(component)
@@ -4114,14 +4116,15 @@ function _append_importpath(ctx, path_spec, path)
             throw(LoweringError(component, "invalid import path: `.` in identifier path"))
         end
         prev_was_dot = is_dot
-        push!(path_spec, @ast(ctx, component, name::K"String"))
+        push!(path_spec.args, Symbol(name))
     end
-    path_spec
+    return path_spec
 end
 
-function expand_import(ctx, ex)
+function expand_import_or_using(ctx, ex)
     is_using = kind(ex) == K"using"
-    if kind(ex[1]) == K":"
+    has_from_path = kind(ex[1]) == K":"
+    if has_from_path
         # import M: x.y as z, w
         # (import (: (importpath M) (as (importpath x y) z) (importpath w)))
         # =>
@@ -4131,47 +4134,50 @@ function expand_import(ctx, ex)
         #  (call core.svec  2 "x" "y" "z"  1 "w" "w"))
         @chk numchildren(ex[1]) >= 2
         from = ex[1][1]
-        @chk kind(from) == K"importpath"
-        from_path = @ast ctx from [K"call"
-            "svec"::K"core"
-            _append_importpath(ctx, SyntaxList(ctx), from)...
-        ]
+        from_path = @ast ctx from QuoteNode(expand_importpath(from))::K"Value"
         paths = ex[1][2:end]
     else
         # import A.B
         # (using (importpath A B))
-        # (call module_import true nothing (call core.svec 1 "w"))
+        # (call eval_import true nothing (call core.svec 1 "w"))
         @chk numchildren(ex) >= 1
         from_path = nothing_(ctx, ex)
         paths = children(ex)
     end
-    path_spec = SyntaxList(ctx)
-    for path in paths
+    # Here we represent the paths as quoted `Expr` data structures
+    path_specs = SyntaxList(ctx)
+    for spec in paths
         as_name = nothing
-        if kind(path) == K"as"
-            @chk numchildren(path) == 2
-            as_name = path[2]
-            @chk kind(as_name) == K"Identifier"
-            path = path[1]
+        if kind(spec) == K"as"
+            @chk numchildren(spec) == 2
+            @chk kind(spec[2]) == K"Identifier"
+            as_name = Symbol(spec[2].name_val)
+            path = QuoteNode(Expr(:as, expand_importpath(spec[1]), as_name))
+        else
+            path = QuoteNode(expand_importpath(spec))
         end
-        @chk kind(path) == K"importpath"
-        push!(path_spec, @ast(ctx, path, numchildren(path)::K"Integer"))
-        _append_importpath(ctx, path_spec, path)
-        push!(path_spec, isnothing(as_name) ? nothing_(ctx, ex) :
-                         @ast(ctx, as_name, as_name.name_val::K"String"))
+        push!(path_specs, @ast ctx spec path::K"Value")
     end
     @ast ctx ex [K"block"
         [K"assert" "toplevel_only"::K"Symbol" [K"inert" ex]]
-        [K"call"
-            module_import ::K"Value"
-            ctx.mod       ::K"Value"
-            is_using      ::K"Value"
-            from_path
+        if is_using && !has_from_path
+            # Using A, B - rather different from
             [K"call"
-                "svec"::K"core"
-                path_spec...
+                "_eval_using"::K"top"
+                ctx.mod      ::K"Value"
+                path_specs...
             ]
-        ]
+        else
+            [K"call"
+                "_eval_import"::K"top"
+                (!is_using)   ::K"Bool"
+                ctx.mod       ::K"Value"
+                from_path
+                path_specs...
+            ]
+        end
+        ::K"latestworld"
+        [K"removable" "nothing"::K"core"]
     ]
 end
 
@@ -4421,7 +4427,7 @@ function expand_forms_2(ctx::DesugaringContext, ex::SyntaxTree, docs=nothing)
     elseif k == K"module"
         expand_module(ctx, ex)
     elseif k == K"import" || k == K"using"
-        expand_import(ctx, ex)
+        expand_import_or_using(ctx, ex)
     elseif k == K"export" || k == K"public"
         expand_public(ctx, ex)
     elseif k == K"abstract" || k == K"primitive"

--- a/src/linear_ir.jl
+++ b/src/linear_ir.jl
@@ -855,6 +855,9 @@ function compile(ctx::LinearIRContext, ex, needs_value, in_tail_pos)
         end
         ctx.is_toplevel_thunk && emit_latestworld(ctx, ex)
     elseif k == K"latestworld"
+        if needs_value
+            throw(LoweringError(ex, "misplaced latestsworld"))
+        end
         emit_latestworld(ctx, ex)
     elseif k == K"latestworld_if_toplevel"
         ctx.is_toplevel_thunk && emit_latestworld(ctx, ex)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -110,7 +110,7 @@ end
 
 #--------------------------------------------------
 # Functions called by closure conversion
-function eval_closure_type(mod, closure_type_name, field_names, field_is_box)
+function eval_closure_type(mod::Module, closure_type_name::Symbol, field_names, field_is_box)
     type_params = Core.TypeVar[]
     field_types = []
     for (name, isbox) in zip(field_names, field_is_box)
@@ -129,7 +129,7 @@ function eval_closure_type(mod, closure_type_name, field_names, field_is_box)
                             false,
                             length(field_names))
     Core._setsuper!(type, Core.Function)
-    Base.eval(mod, :(const $closure_type_name = $type))
+    @ccall jl_set_const(mod::Module, closure_type_name::Symbol, type::Any)::Cvoid
     Core._typebody!(false, type, Core.svec(field_types...))
     type
 end
@@ -174,38 +174,6 @@ function eval_module(parentmod, modname, body)
             $eval($name, $body)
         end
     ))
-end
-
-# Evaluate content of `import` or `using` statement
-function module_import(into_mod::Module, is_using::Bool,
-                       from_mod::Union{Nothing,Core.SimpleVector}, paths::Core.SimpleVector)
-    # For now, this function converts our lowered representation back to Expr
-    # and calls eval() to avoid replicating all of the fiddly logic in
-    # jl_toplevel_eval_flex.
-    # TODO: ccall Julia runtime functions directly?
-    #   * jl_module_using jl_module_use_as
-    #   * import_module jl_module_import_as
-    path_args = []
-    i = 1
-    while i < length(paths)
-        nsyms = paths[i]::Int
-        n = i + nsyms
-        path = Expr(:., [Symbol(paths[i+j]::String) for j = 1:nsyms]...)
-        as_name = paths[i+nsyms+1]
-        push!(path_args, isnothing(as_name) ? path :
-                         Expr(:as, path, Symbol(as_name)))
-        i += nsyms + 2
-    end
-    ex = if isnothing(from_mod)
-        Expr(is_using ? :using : :import,
-             path_args...)
-    else
-        from_path = Expr(:., [Symbol(s::String) for s in from_mod]...)
-        Expr(is_using ? :using : :import,
-             Expr(:(:), from_path, path_args...))
-    end
-    eval(into_mod, ex)
-    nothing
 end
 
 function module_public(mod::Module, is_exported::Bool, identifiers...)

--- a/test/import_ir.jl
+++ b/test/import_ir.jl
@@ -2,36 +2,33 @@
 # Basic import
 import A: b
 #---------------------
-1   (call core.svec "A")
-2   (call core.svec 1 "b" core.nothing)
-3   (call JuliaLowering.module_import TestMod false %₁ %₂)
-4   (return %₃)
+1   (call top._eval_import true TestMod :($(QuoteNode(:($(Expr(:., :A)))))) :($(QuoteNode(:($(Expr(:., :b)))))))
+2   latestworld
+3   (return core.nothing)
 
 ########################################
 # Import with paths and `as`
 import A.B.C: b, c.d as e
 #---------------------
-1   (call core.svec "A" "B" "C")
-2   (call core.svec 1 "b" core.nothing 2 "c" "d" "e")
-3   (call JuliaLowering.module_import TestMod false %₁ %₂)
-4   (return %₃)
+1   (call top._eval_import true TestMod :($(QuoteNode(:($(Expr(:., :A, :B, :C)))))) :($(QuoteNode(:($(Expr(:., :b)))))) :($(QuoteNode(:(c.d as e)))))
+2   latestworld
+3   (return core.nothing)
 
 ########################################
 # Using
 using A
 #---------------------
-1   (call core.svec 1 "A" core.nothing)
-2   (call JuliaLowering.module_import TestMod true core.nothing %₁)
-3   (return %₂)
+1   (call top._eval_using TestMod :($(QuoteNode(:($(Expr(:., :A)))))))
+2   latestworld
+3   (return core.nothing)
 
 ########################################
 # Using with paths and `as`
 using A.B.C: b, c.d as e
 #---------------------
-1   (call core.svec "A" "B" "C")
-2   (call core.svec 1 "b" core.nothing 2 "c" "d" "e")
-3   (call JuliaLowering.module_import TestMod true %₁ %₂)
-4   (return %₃)
+1   (call top._eval_import false TestMod :($(QuoteNode(:($(Expr(:., :A, :B, :C)))))) :($(QuoteNode(:($(Expr(:., :b)))))) :($(QuoteNode(:(c.d as e)))))
+2   latestworld
+3   (return core.nothing)
 
 ########################################
 # Error: Import not at top level


### PR DESCRIPTION
Calls to `import` and `using` are expanded by lowering as of the changes in https://github.com/JuliaLang/julia/pull/57965 and no longer dealt with by the C function `jl_toplevel_eval_flex`.

This implies we can't use `eval()` for these if we want to activate JuliaLowering in Core, or we'll hit a stack overflow.

I've chosen to duplicate the flisp lowering here for consistency and import paths are thus lowered to a restricted kind of quoted `Expr`. (It's mildly annoying to rely on quoted `Expr` in the lowered paths than the previous use of `Core.svec` but deleting the svec representation allows us to use `Base._eval_import` and `Base._eval_using` directly so seems like a worthy simplification.)

Fix #42