### PR TITLE
Fix IR generation for `return` in value position

### DIFF
--- a/src/linear_ir.jl
+++ b/src/linear_ir.jl
@@ -342,7 +342,7 @@ function emit_assignment(ctx, srcref, lhs, rhs, op=K"=")
     else
         # in unreachable code (such as after return); still emit the assignment
         # so that the structure of those uses is preserved
-        emit_simple_assignment(ctx, srcref, lhs, @ast ctx srcref "nothing"::K"core", op)
+        emit_simple_assignment(ctx, srcref, lhs, nothing_(ctx, srcref), op)
         nothing
     end
 end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -159,6 +159,16 @@ begin
 end
 """)
 
+@test JuliaLowering.include_string(test_mod, """
+x = 0
+function f_return_in_value_pos()
+    global x
+    x = return 42
+end
+
+(f_return_in_value_pos(), x)
+""") === (42, 0)
+
 @testset "Default positional arguments" begin
     @test JuliaLowering.include_string(test_mod, """
     begin

--- a/test/functions_ir.jl
+++ b/test/functions_ir.jl
@@ -996,6 +996,28 @@ end
 12  (return %₁₁)
 
 ########################################
+# Function return in value position is allowed
+function f()
+    x = return 1
+end
+#---------------------
+1   (method TestMod.f)
+2   latestworld
+3   TestMod.f
+4   (call core.Typeof %₃)
+5   (call core.svec %₄)
+6   (call core.svec)
+7   SourceLocation::1:10
+8   (call core.svec %₅ %₆ %₇)
+9   --- method core.nothing %₈
+    slots: [slot₁/#self#(!read) slot₂/x(!read)]
+    1   (return 1)
+    2   (= slot₂/x core.nothing)
+10  latestworld
+11  TestMod.f
+12  (return %₁₁)
+
+########################################
 # Binding docs to functions
 """
 some docs


### PR DESCRIPTION
Fixes #46

(Got broken with the `op` argument added in #10 but I hadn't written a test case for this code path :sweat_smile:)