### PR TITLE
SyntaxGraph: Usability and performance tweaks

### DIFF
--- a/src/ast.jl
+++ b/src/ast.jl
@@ -428,33 +428,47 @@ end
 
 
 """
-Recursively copy AST `ex` into `ctx`.  The resulting tree contains new nodes
-only, and does not contain nodes with multiple parents.
+Recursively copy AST `ex` into `ctx`.
 
 Special provenance handling: If `copy_source` is true, treat the `.source`
 attribute as a reference and recurse on its contents.  Otherwise, treat it like
 any other attribute.
 """
-function copy_ast(ctx, ex; copy_source=true)
-    # TODO: Do we need to keep a mapping of node IDs to ensure we don't
-    # double-copy here in the case when some tree nodes are pointed to by
-    # multiple parents? (How much does this actually happen in practice?)
-    s = get(ex, :source, nothing)
-    # TODO: Figure out how to use provenance() here?
-    srcref = !copy_source ? s                                                  :
-             s isa NodeId ? copy_ast(ctx, SyntaxTree(ex._graph, s))            :
-             s isa Tuple  ? map(i->copy_ast(ctx, SyntaxTree(ex._graph, i)), s) :
-             s
-    if !is_leaf(ex)
-        cs = SyntaxList(ctx)
-        for e in children(ex)
-            push!(cs, copy_ast(ctx, e))
-        end
-        ex2 = makenode(ctx, srcref, ex, cs)
-    else
-        ex2 = makeleaf(ctx, srcref, ex)
+function copy_ast(ctx, ex::SyntaxTree; copy_source=true)
+    graph1 = syntax_graph(ex)
+    graph2 = syntax_graph(ctx)
+    !copy_source && check_same_graph(graph1, graph2)
+    id2 = _copy_ast(graph2, graph1, ex._id, Dict{NodeId, NodeId}(), copy_source)
+    return SyntaxTree(graph2, id2)
+end
+
+function _copy_ast(graph2::SyntaxGraph, graph1::SyntaxGraph,
+                   id1::NodeId, seen, copy_source)
+    let copied = get(seen, id1, nothing)
+        isnothing(copied) || return copied
     end
-    return ex2
+    id2 = newnode!(graph2)
+    seen[id1] = id2
+    src1 = get(SyntaxTree(graph1, id1), :source, nothing)
+    src2 = if !copy_source
+        src1
+    elseif src1 isa NodeId
+        _copy_ast(graph2, graph1, src1, seen, copy_source)
+    elseif src1 isa Tuple
+        map(i->_copy_ast(graph2, graph1, i, seen, copy_source), src1)
+    else
+        src1
+    end
+    copy_attrs!(SyntaxTree(graph2, id2), SyntaxTree(graph1, id1), true)
+    setattr!(graph2, id2; source=src2)
+    if !is_leaf(graph1, id1)
+        cs = NodeId[]
+        for cid in children(graph1, id1)
+            push!(cs, _copy_ast(graph2, graph1, cid, seen, copy_source))
+        end
+        setchildren!(graph2, id2, cs)
+    end
+    return id2
 end
 
 #-------------------------------------------------------------------------------

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -438,7 +438,7 @@ attrsummary(name, value::Number) = "$name=$value"
 
 function _value_string(ex)
     k = kind(ex)
-    str = k == K"Identifier" || k == K"MacroName" || is_operator(k) ? ex.name_val :
+    str = k in KSet"Identifier MacroName StringMacroName CmdMacroName" || is_operator(k) ? ex.name_val :
           k == K"Placeholder" ? ex.name_val           :
           k == K"SSAValue"    ? "%"                   :
           k == K"BindingId"   ? "#"                   :

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -213,7 +213,9 @@ function Base.getproperty(ex::SyntaxTree, name::Symbol)
     name === :_id  && return getfield(ex, :_id)
     _id = getfield(ex, :_id)
     return get(getproperty(getfield(ex, :_graph), name), _id) do
-        error("Property `$name[$_id]` not found")
+        attrstr = join(["\n    $n = $(getproperty(ex, n))"
+                        for n in attrnames(ex)], ",")
+        error("Property `$name[$_id]` not found. Available attributes:$attrstr")
     end
 end
 

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -434,10 +434,10 @@ end
 
 const SourceAttrType = Union{SourceRef,LineNumberNode,NodeId,Tuple}
 
-function SyntaxTree(graph::SyntaxGraph, node::SyntaxNode)
+function SyntaxTree(graph::SyntaxGraph{<:Dict}, node::SyntaxNode)
     ensure_attributes!(graph, kind=Kind, syntax_flags=UInt16, source=SourceAttrType,
                        value=Any, name_val=String)
-    id = _convert_nodes(freeze_attrs(graph), node)
+    id = _convert_nodes(graph, node)
     return SyntaxTree(graph, id)
 end
 

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -22,6 +22,10 @@ function freeze_attrs(graph::SyntaxGraph)
     SyntaxGraph(graph.edge_ranges, graph.edges, frozen_attrs)
 end
 
+function unfreeze_attrs(graph::SyntaxGraph)
+    SyntaxGraph(graph.edge_ranges, graph.edges, Dict(pairs(graph.attributes)...))
+end
+
 function _show_attrs(io, attributes::Dict)
     show(io, MIME("text/plain"), attributes)
 end
@@ -31,6 +35,10 @@ end
 
 function attrnames(graph::SyntaxGraph)
     keys(graph.attributes)
+end
+
+function attrtypes(graph::SyntaxGraph)
+    [(k, typeof(v).parameters[2]) for (k, v) in pairs(graph.attributes)]
 end
 
 function Base.show(io::IO, ::MIME"text/plain", graph::SyntaxGraph)
@@ -54,7 +62,7 @@ function ensure_attributes!(graph::SyntaxGraph{<:Dict}; kws...)
 end
 
 function ensure_attributes(graph::SyntaxGraph; kws...)
-    g = SyntaxGraph(graph.edge_ranges, graph.edges, Dict(pairs(graph.attributes)...))
+    g = unfreeze_attrs(graph)
     ensure_attributes!(g; kws...)
     freeze_attrs(g)
 end

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -39,7 +39,7 @@ function Base.show(io::IO, ::MIME"text/plain", graph::SyntaxGraph)
     _show_attrs(io, graph.attributes)
 end
 
-function ensure_attributes!(graph::SyntaxGraph; kws...)
+function ensure_attributes!(graph::SyntaxGraph{<:Dict}; kws...)
     for (k,v) in pairs(kws)
         @assert k isa Symbol
         @assert v isa Type

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -23,7 +23,8 @@ function freeze_attrs(graph::SyntaxGraph)
 end
 
 function unfreeze_attrs(graph::SyntaxGraph)
-    SyntaxGraph(graph.edge_ranges, graph.edges, Dict(pairs(graph.attributes)...))
+    unfrozen_attrs = Dict{Symbol,Any}(pairs(graph.attributes)...)
+    SyntaxGraph(graph.edge_ranges, graph.edges, unfrozen_attrs)
 end
 
 function _show_attrs(io, attributes::Dict)

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -60,19 +60,31 @@ function ensure_attributes!(graph::SyntaxGraph{<:Dict}; kws...)
     end
     graph
 end
+function ensure_attributes(graph::SyntaxGraph{<:Dict}; kws...)
+    g = unfreeze_attrs(graph)
+    ensure_attributes!(g; kws...)
+end
 
-function ensure_attributes(graph::SyntaxGraph; kws...)
+function ensure_attributes(graph::SyntaxGraph{<:NamedTuple}; kws...)
     g = unfreeze_attrs(graph)
     ensure_attributes!(g; kws...)
     freeze_attrs(g)
 end
 
-function delete_attributes(graph::SyntaxGraph, attr_names...)
-    attributes = Dict(pairs(graph.attributes)...)
+function delete_attributes!(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
     for name in attr_names
-        delete!(attributes, name)
+        delete!(graph.attributes, name)
     end
-    SyntaxGraph(graph.edge_ranges, graph.edges, (; pairs(attributes)...))
+    graph
+end
+
+function delete_attributes(graph::SyntaxGraph{<:Dict}, attr_names::Symbol...)
+    delete_attributes!(unfreeze_attrs(graph), attr_names...)
+end
+
+function delete_attributes(graph::SyntaxGraph{<:NamedTuple}, attr_names::Symbol...)
+    g = delete_attributes!(unfreeze_attrs(graph), attr_names...)
+    freeze_attrs(g)
 end
 
 function newnode!(graph::SyntaxGraph)

--- a/test/syntax_graph.jl
+++ b/test/syntax_graph.jl
@@ -16,12 +16,12 @@
     @test gf2.attributes isa NamedTuple
     @test gu2.attributes isa Dict
     # does its job
-    @test (:test_attr, Symbol) in JuliaLowering.attrtypes(gf2)
-    @test (:foo, Type) in JuliaLowering.attrtypes(gf2)
+    @test (:test_attr=>Symbol) in JuliaLowering.attrdefs(gf2)
+    @test (:foo=>Type) in JuliaLowering.attrdefs(gf2)
     @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
     # no mutation
-    @test !((:test_attr, Symbol) in JuliaLowering.attrtypes(gf1))
-    @test !((:foo, Type) in JuliaLowering.attrtypes(gf1))
+    @test !((:test_attr=>Symbol) in JuliaLowering.attrdefs(gf1))
+    @test !((:foo=>Type) in JuliaLowering.attrdefs(gf1))
     @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
 
     # delete_attributes
@@ -31,12 +31,12 @@
     @test gf3.attributes isa NamedTuple
     @test gu3.attributes isa Dict
     # does its job
-    @test !((:test_attr, Symbol) in JuliaLowering.attrtypes(gf3))
-    @test !((:foo, Type) in JuliaLowering.attrtypes(gf3))
+    @test !((:test_attr=>Symbol) in JuliaLowering.attrdefs(gf3))
+    @test !((:foo=>Type) in JuliaLowering.attrdefs(gf3))
     @test Set(keys(gf3.attributes)) == Set(keys(gu3.attributes))
     # no mutation
-    @test (:test_attr, Symbol) in JuliaLowering.attrtypes(gf2)
-    @test (:foo, Type) in JuliaLowering.attrtypes(gf2)
+    @test (:test_attr=>Symbol) in JuliaLowering.attrdefs(gf2)
+    @test (:foo=>Type) in JuliaLowering.attrdefs(gf2)
     @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
 end
 

--- a/test/syntax_graph.jl
+++ b/test/syntax_graph.jl
@@ -1,3 +1,45 @@
+@testset "SyntaxGraph attrs" begin
+    st = parsestmt(SyntaxTree, "function foo end")
+    g_init = JuliaLowering.unfreeze_attrs(st._graph)
+    gf1 = JuliaLowering.freeze_attrs(g_init)
+    gu1 = JuliaLowering.unfreeze_attrs(gf1)
+
+    # Check that freeze/unfreeze do their jobs
+    @test gf1.attributes isa NamedTuple
+    @test gu1.attributes isa Dict
+    @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
+
+    # ensure_attributes
+    gf2 = JuliaLowering.ensure_attributes(gf1, test_attr=Symbol, foo=Type)
+    gu2 = JuliaLowering.ensure_attributes(gu1, test_attr=Symbol, foo=Type)
+    # returns a graph with the same attribute storage
+    @test gf2.attributes isa NamedTuple
+    @test gu2.attributes isa Dict
+    # does its job
+    @test (:test_attr, Symbol) in JuliaLowering.attrtypes(gf2)
+    @test (:foo, Type) in JuliaLowering.attrtypes(gf2)
+    @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
+    # no mutation
+    @test !((:test_attr, Symbol) in JuliaLowering.attrtypes(gf1))
+    @test !((:foo, Type) in JuliaLowering.attrtypes(gf1))
+    @test Set(keys(gf1.attributes)) == Set(keys(gu1.attributes))
+
+    # delete_attributes
+    gf3 = JuliaLowering.delete_attributes(gf2, :test_attr, :foo)
+    gu3 = JuliaLowering.delete_attributes(gu2, :test_attr, :foo)
+    # returns a graph with the same attribute storage
+    @test gf3.attributes isa NamedTuple
+    @test gu3.attributes isa Dict
+    # does its job
+    @test !((:test_attr, Symbol) in JuliaLowering.attrtypes(gf3))
+    @test !((:foo, Type) in JuliaLowering.attrtypes(gf3))
+    @test Set(keys(gf3.attributes)) == Set(keys(gu3.attributes))
+    # no mutation
+    @test (:test_attr, Symbol) in JuliaLowering.attrtypes(gf2)
+    @test (:foo, Type) in JuliaLowering.attrtypes(gf2)
+    @test Set(keys(gf2.attributes)) == Set(keys(gu2.attributes))
+end
+
 @testset "SyntaxTree" begin
     # Expr conversion
     @test Expr(parsestmt(SyntaxTree, "begin a + b ; c end", filename="none")) ==


### PR DESCRIPTION
Several small `SyntaxGraph` tweaks.  Some of these have been split out from #35 since they are tiny improvements that don't need to wait for data size experimentation.

Changes worth discussing:
## Do not coerce attributes to NamedTuple unnecessarily

It doesn't make sense to freeze Dict-attributes to NamedTuple after an `ensure_attributes` or `delete_attributes` call.  I assume this freezing was unintentional and not detected because the attribute storage type abstraction is implemented quite well.

Note that this change increases precompile time and decreases test time.  Below are outputs from `@time using JuliaLowering` and `@time include("test/runtests.jl")`

Before:
  - 45.395172 seconds (927.27 k allocations: 57.289 MiB, 0.08% gc time, 0.17% compilation time)
  - 24.653554 seconds (78.07 M allocations: 4.079 GiB, 4.25% gc time, 95.33% compilation time: <1% of which was recompilation)

After:
  - 59.053901 seconds (1.12 M allocations: 70.427 MiB, 0.06% gc time, 0.13% compilation time)
  - 11.100739 seconds (35.53 M allocations: 1.789 GiB, 4.09% gc time, 90.51% compilation time: 2% of which was recompilation)

(Our precompile statements could probably use some tweaking still)

## Delete ineffective freeze_attrs call

This post-parsing freeze call wasn't doing anything.  The freezing we got was actually from `ensure_attributes`.  The output of lowering now has Dict-attributes, which I think are fine, but if we want to freeze post-lowering we can do that.  Making the call effective has a bad effect on the test time above.

## Print more information when node does not have attribute (and no default is provided)

This is an unrecoverable error anyway, so print a bit more information about the node we tried to access.  Before:
  ```
  julia> st = jlower("function foo end")
  julia> st.value
  ERROR: Property `value[33]` not found
  ```
  After:
  ```
  julia> st.value
  ERROR: Property `value[33]` not found. Available attributes:
    kind = code_info,
    is_toplevel_thunk = true,
    source = 21,
    slots = JuliaLowering.Slot[]
  ```
