### PR TITLE
compat: support `Base.Experimental.@force_compile`

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -420,7 +420,7 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         elseif e.args[1] in (:inline, :noinline, :generated, :generated_only,
                              :max_methods, :optlevel, :toplevel, :push_loc, :pop_loc,
                              :aggressive_constprop, :specialize, :compile, :infer,
-                             :nospecializeinfer)
+                             :nospecializeinfer, :force_compile)
             # TODO: Some need to be handled in lowering
             child_exprs[1] = Expr(:quoted_symbol, e.args[1])
         else
@@ -428,7 +428,7 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
             @error("Unknown meta form at $src: `$e`\n$(sprint(dump, e))")
             child_exprs[1] = Expr(:quoted_symbol, e.args[1])
         end
-    elseif e.head === :scope_layer 
+    elseif e.head === :scope_layer
         @assert nargs === 2
         @assert e.args[1] isa Symbol
         @assert e.args[2] isa LayerId

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -420,7 +420,7 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         elseif e.args[1] in (:inline, :noinline, :generated, :generated_only,
                              :max_methods, :optlevel, :toplevel, :push_loc, :pop_loc,
                              :aggressive_constprop, :specialize, :compile, :infer,
-                             :nospecializeinfer, :force_compile)
+                             :nospecializeinfer, :force_compile, :doc)
             # TODO: Some need to be handled in lowering
             child_exprs[1] = Expr(:quoted_symbol, e.args[1])
         else


### PR DESCRIPTION
`:meta, :force_compile` is one of the forms known by the compiler.