### PR TITLE
Fixes for quote interpolation in Expr compat mode

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -261,7 +261,8 @@ function to_lowered_expr(mod, ex, ssa_offset=0)
     elseif k == K"return"
         Core.ReturnNode(to_lowered_expr(mod, ex[1], ssa_offset))
     elseif k == K"inert"
-        ex[1]
+        e1 = ex[1]
+        getmeta(ex, :as_Expr, false) ? QuoteNode(Expr(e1)) : e1
     elseif k == K"code_info"
         funcname = ex.is_toplevel_thunk ?
             "top-level scope" :
@@ -391,7 +392,8 @@ end
 
 Like `include`, except reads code from the given string rather than from a file.
 """
-function include_string(mod::Module, code::AbstractString, filename::AbstractString="string")
-    eval(mod, parseall(SyntaxTree, code; filename=filename))
+function include_string(mod::Module, code::AbstractString, filename::AbstractString="string";
+                        expr_compat_mode=false)
+    eval(mod, parseall(SyntaxTree, code; filename=filename); expr_compat_mode)
 end
 

--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -57,7 +57,7 @@ function expand_quote(ctx, ex)
     # the entire expression produced by `quote` expansion. We could, but it
     # seems unnecessary for `quote` because the surface syntax is a transparent
     # representation of the expansion process. However, it's useful to add the
-    # extra srcref in a more targetted way for $ interpolations inside
+    # extra srcref in a more targeted way for $ interpolations inside
     # interpolate_ast, so we do that there.
     #
     # In principle, particular user-defined macros could opt into a similar
@@ -69,7 +69,7 @@ function expand_quote(ctx, ex)
     @ast ctx ex [K"call"
         interpolate_ast::K"Value"
         (ctx.expr_compat_mode ? Expr : SyntaxTree)::K"Value"
-        [K"inert" ex]
+        [K"inert"(meta=CompileHints(:as_Expr, ctx.expr_compat_mode)) ex]
         unquoted...
     ]
 end

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -554,7 +554,14 @@ function JuliaSyntax._expr_leaf_val(ex::SyntaxTree, _...)
             n
         end
     else
-        get(ex, :value, nothing)
+        val = get(ex, :value, nothing)
+        if kind(ex) == K"Value" && val isa Expr || val isa LineNumberNode
+            # Expr AST embedded in a SyntaxTree should be quoted rather than
+            # becoming part of the output AST.
+            QuoteNode(val)
+        else
+            val
+        end
     end
 end
 
@@ -745,6 +752,7 @@ end
 
 function Base.deleteat!(v::SyntaxList, inds)
     deleteat!(v.ids, inds)
+    v
 end
 
 function Base.copy(v::SyntaxList)


### PR DESCRIPTION
Ensure that interpolating values into quoted expressions works in Expr compat mode.

* To produce `Expr` in `CodeInfo` conversion, add an `as_Expr` meta attribute to `K"inert"` generated by `expand_quote`.  I left this as a meta attribute because it doesn't need to be strongly typed.
* In analogy with `eval()`, add `expr_compat_mode` keyword to `include_string`. We may want to rethink this when we rethink how options to `eval()` work.
* Adapt the runtime function `interpolate_ast` to work with both `Expr` and `SyntaxTree` as the source expression.
* Allow `Symbol` to be interpolated into `SyntaxTree` as syntax rather than a `K"Value": Even in "new style macro mode", `:x` is interpreted as a `Symbol` rather than an AST as it's used by many packages as a kind of lightweight untyped enum (ie, a usage which is almost entirely unrelated to AST manipulation)
* Fix `SyntaxTree->Expr` conversion so that embedded Expr `K"Value"` means a leaf, not an embedded tree.

Follows up on #44, in particular, resolves the comment at https://github.com/c42f/JuliaLowering.jl/pull/44#discussion_r2292704794_

In terms of the implementation, I tried the alternative of keeping `SyntaxTree` in the `CodeInfo` rather than `Expr` and using that as the reference expression in `interpolate_ast` - I had hoped this might be cleaner and less effort. However, this approach ends up needing a "partial" non-recursive implementation of `Expr->SyntaxTree` conversion (in particular, one where child nodes have already been converted) and that would have required more changes on the `JuliaSyntax` side than I wanted.  However, we might need that kind of non-recursive machinery in the future. For example, for customizing SyntaxTree->Expr conversion - if we do, we can reconsider the implementation of `interpolate_ast` at that point.