### PR TITLE
Fixes for escape handling in `Expr->SyntaxTree` conversion

### DIFF
--- a/src/ast.jl
+++ b/src/ast.jl
@@ -142,7 +142,8 @@ end
 function makeleaf(ctx, srcref, k::Kind, value; kws...)
     graph = syntax_graph(ctx)
     if k == K"Identifier" || k == K"core" || k == K"top" || k == K"Symbol" ||
-            k == K"globalref" || k == K"Placeholder"
+            k == K"globalref" || k == K"Placeholder" || k == K"MacroName" ||
+            k == "StringMacroName" || k == K"CmdMacroName"
         makeleaf(graph, srcref, k; name_val=value, kws...)
     elseif k == K"BindingId"
         makeleaf(graph, srcref, k; var_id=value, kws...)

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -34,7 +34,7 @@ function expr_to_syntaxtree(ctx, @nospecialize(e), lnn::Union{LineNumberNode, No
     toplevel_src = if isnothing(lnn)
         # Provenance sinkhole for all nodes until we hit a linenode
         dummy_src = SourceRef(
-            SourceFile("No source for expression: $e"),
+            SourceFile("No source for expression"),
             1, JS.GreenNode(K"None", 0))
         _insert_tree_node(graph, K"None", dummy_src)
     else
@@ -91,21 +91,23 @@ function collect_expr_parameters(e::Expr, pos::Int)
     args = Any[e.args[1:pos-1]..., e.args[pos+1:end]...]
     return _flatten_params!(args, params)
 end
-function _flatten_params!(out::Vector{Any}, p::Expr)
+function _flatten_params!(out::Vector{Any}, params::Expr)
+    p,p_esc = unwrap_esc(params)
     p1 = expr_parameters(p, 1)
     if !isnothing(p1)
-        push!(out, Expr(:parameters, p.args[2:end]...))
-        _flatten_params!(out, p1)
+        push!(out, p_esc(Expr(:parameters, p.args[2:end]...)))
+        _flatten_params!(out, p_esc(p1))
     else
-        push!(out, p::Any)
+        push!(out, params::Any)
     end
     return out
 end
 function expr_parameters(p::Expr, pos::Int)
-    if length(p.args) >= pos &&
-        p.args[pos] isa Expr &&
-        p.args[pos].head === :parameters
-        return p.args[pos]
+    if pos <= length(p.args)
+        e,_ = unwrap_esc(p.args[pos])
+        if e isa Expr && e.head === :parameters
+            return p.args[pos]
+        end
     end
     return nothing
 end
@@ -113,7 +115,10 @@ end
 """
 If `b` (usually a block) has exactly one non-LineNumberNode argument, unwrap it.
 """
-function maybe_unwrap_arg(b::Expr)
+function maybe_unwrap_arg(b)
+    if !(b isa Expr)
+        return b
+    end
     e1 = findfirst(c -> !isa(c, LineNumberNode), b.args)
     isnothing(e1) && return b
     e2 = findfirst(c -> !isa(c, LineNumberNode), b.args[e1+1:end])
@@ -122,7 +127,7 @@ function maybe_unwrap_arg(b::Expr)
 end
 
 function maybe_extract_lnn(b, default)
-    !(b isa Expr) && return b
+    !(b isa Expr) && return default
     lnn_i = findfirst(a->isa(a, LineNumberNode), b.args)
     return isnothing(lnn_i) ? default : b.args[lnn_i]
 end
@@ -141,7 +146,33 @@ end
 
 function is_eventually_call(e)
     return e isa Expr && (e.head === :call ||
-        e.head in (:where, :(::)) && is_eventually_call(e.args[1]))
+        e.head in (:escape, :where, :(::)) && is_eventually_call(e.args[1]))
+end
+
+function rewrap_escapes(hyg, ex)
+    if hyg isa Expr && hyg.head in (:escape, :var"hygienic-scope")
+        ex = Expr(hyg.head, rewrap_escapes(hyg.args[1], ex))
+        if hyg.head === :var"hygienic-scope"
+            append!(ex.args, @view hyg.args[2:end])
+        end
+    end
+    return ex
+end
+
+# Unwrap Expr(:escape) and Expr(:hygienic-scope). Return the unwrapped
+# expression and a function which will rewrap a derived expression in the
+# correct hygiene wrapper.
+function unwrap_esc(ex)
+    orig_ex = ex
+    while ex isa Expr && ex.head in (:escape, :var"hygienic-scope")
+        @assert length(ex.args) >= 1
+        ex = ex.args[1]
+    end
+    return ex, e->rewrap_escapes(orig_ex, e)
+end
+
+function unwrap_esc_(e)
+    unwrap_esc(e)[1]
 end
 
 """
@@ -212,25 +243,29 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         child_exprs = Any[e.args[1], Symbol(op), e.args[2]]
     elseif e.head === :comparison
         for i = 2:2:length(child_exprs)
-            op = child_exprs[i]
+            op,op_esc = unwrap_esc(child_exprs[i])
             @assert op isa Symbol
             op_s = string(op)
             if is_dotted_operator(op_s)
-                child_exprs[i] = Expr(:., Symbol(op_s[2:end]))
+                child_exprs[i] = Expr(:., op_esc(Symbol(op_s[2:end])))
             end
         end
     elseif e.head === :macrocall
         @assert nargs >= 2
-        a1 = e.args[1]
+        a1,a1_esc = unwrap_esc(e.args[1])
         child_exprs = collect_expr_parameters(e, 3)
         if child_exprs[2] isa LineNumberNode
             src = child_exprs[2]
         end
         deleteat!(child_exprs, 2)
         if a1 isa Symbol
-            child_exprs[1] = Expr(:MacroName, a1)
-        elseif a1 isa Expr && a1.head === :(.) && a1.args[2] isa QuoteNode
-            child_exprs[1] = Expr(:(.), a1.args[1], Expr(:MacroName, a1.args[2].value))
+            child_exprs[1] = a1_esc(Expr(:MacroName, a1))
+        elseif a1 isa Expr && a1.head === :(.)
+            a12,a12_esc = unwrap_esc(a1.args[2])
+            if a12 isa QuoteNode
+                child_exprs[1] = a1_esc(Expr(:(.), a1.args[1],
+                                             Expr(:MacroName, a12_esc(a12.value))))
+            end
         elseif a1 isa GlobalRef
             # TODO (maybe): syntax-introduced macrocalls are listed here for
             # reference.  We probably don't need to convert these.
@@ -240,31 +275,27 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
             elseif a1.name === Symbol("@int128_str")
             elseif a1.name === Symbol("@big_str")
             end
-        elseif a1 isa Function
-            # pass
-        else
-            error("Unknown macrocall form at $src: $(sprint(dump, e))")
-            @assert false
         end
     elseif e.head === Symbol("'")
         @assert nargs === 1
         st_k = K"call"
         child_exprs = Any[e.head, e.args[1]]
     elseif e.head === :. && nargs === 2
-        a2 = e.args[2]
+        a2, a2_esc = unwrap_esc(e.args[2])
         if a2 isa Expr && a2.head === :tuple
             st_k = K"dotcall"
-            tuple_exprs = collect_expr_parameters(a2, 1)
+            tuple_exprs = collect_expr_parameters(a2_esc(a2), 1)
             child_exprs = pushfirst!(tuple_exprs, e.args[1])
         elseif a2 isa QuoteNode
-            child_exprs[2] = a2.value
+            child_exprs[2] = a2_esc(a2.value)
         end
     elseif e.head === :for
         @assert nargs === 2
         child_exprs = Any[_to_iterspec(Any[e.args[1]], false), e.args[2]]
     elseif e.head === :where
         @assert nargs >= 2
-        if !(e.args[2] isa Expr && e.args[2].head === :braces)
+        e2,_ = unwrap_esc(e.args[2])
+        if !(e2 isa Expr && e2.head === :braces)
             child_exprs = Any[e.args[1], Expr(:braces, e.args[2:end]...)]
         end
     elseif e.head in (:tuple, :vect, :braces)
@@ -281,18 +312,19 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         #        [catch var (block ...)]
         #        [else (block ...)]
         #        [finally (block ...)])
-        if e.args[2] != false || e.args[3] != false
+        e2 = unwrap_esc_(e.args[2])
+        e3 = unwrap_esc_(e.args[3])
+        if e2 !== false || e3 !== false
             push!(child_exprs,
                   Expr(:catch,
-                       e.args[2] === false ? Expr(:catch_var_placeholder) : e.args[2],
-                       e.args[3] === false ? nothing : e.args[3]))
+                       e2 === false ? Expr(:catch_var_placeholder) : e.args[2],
+                       e3 === false ? nothing : e.args[3]))
         end
         if nargs >= 5
             push!(child_exprs, Expr(:else, e.args[5]))
         end
-        if nargs >= 4
-            push!(child_exprs,
-                  Expr(:finally, e.args[4] === false ? nothing : e.args[4]))
+        if nargs >= 4 && unwrap_esc_(e.args[4]) !== false
+            push!(child_exprs, Expr(:finally, e.args[4]))
         end
     elseif e.head === :flatten || e.head === :generator
         st_k = K"generator"
@@ -307,36 +339,37 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         push!(child_exprs, _to_iterspec(next.args[2:end], true))
         pushfirst!(child_exprs, next.args[1])
     elseif e.head === :ncat || e.head === :nrow
-        dim = popfirst!(child_exprs)
+        dim = unwrap_esc_(popfirst!(child_exprs))
         st_flags |= JS.set_numeric_flags(dim)
     elseif e.head === :typed_ncat
-        st_flags |= JS.set_numeric_flags(e.args[2])
+        st_flags |= JS.set_numeric_flags(unwrap_esc_(e.args[2]))
         deleteat!(child_exprs, 2)
     elseif e.head === :(->)
         @assert nargs === 2
-        if e.args[1] isa Expr && e.args[1].head === :block
+        a1, a1_esc = unwrap_esc(e.args[1])
+        if a1 isa Expr && a1.head === :block
             # Expr parsing fails to make :parameters here...
             lam_args = Any[]
             lam_eqs = Any[]
-            for a in e.args[1].args
+            for a in a1.args
                 a isa Expr && a.head === :(=) ? push!(lam_eqs, a) : push!(lam_args, a)
             end
             !isempty(lam_eqs) && push!(lam_args, Expr(:parameters, lam_eqs...))
-            child_exprs[1] = Expr(:tuple, lam_args...)
-        elseif !(e.args[1] isa Expr && (e.args[1].head in (:tuple, :where)))
-            child_exprs[1] = Expr(:tuple, e.args[1])
+            child_exprs[1] = a1_esc(Expr(:tuple, lam_args...))
+        elseif !(a1 isa Expr && (a1.head in (:tuple, :where)))
+            child_exprs[1] = a1_esc(Expr(:tuple, a1))
         end
         src = maybe_extract_lnn(e.args[2], src)
         child_exprs[2] = maybe_unwrap_arg(e.args[2])
     elseif e.head === :call
         child_exprs = collect_expr_parameters(e, 2)
-        a1 = child_exprs[1]
+        a1,a1_esc = unwrap_esc(child_exprs[1])
         if a1 isa Symbol
             a1s = string(a1)
             if is_dotted_operator(a1s)
                 # non-assigning dotop like .+ or .==
                 st_k = K"dotcall"
-                child_exprs[1] = Symbol(a1s[2:end])
+                child_exprs[1] = a1_esc(Symbol(a1s[2:end]))
             end
         end
     elseif e.head === :function
@@ -362,17 +395,20 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         # SyntaxTree:
         # (call f args... (do (tuple lam_args...) (block ...)))
         callargs = collect_expr_parameters(e.args[1], 2)
-        fname = string(callargs[1])
         if e.args[1].head === :macrocall
             st_k = K"macrocall"
-            callargs[1] = Expr(:MacroName, callargs[1])
+            c1,c1_esc = unwrap_esc(callargs[1])
+            callargs[1] = c1_esc(Expr(:MacroName, c1))
         else
             st_k = K"call"
         end
         child_exprs = Any[callargs..., Expr(:do_lambda, e.args[2].args...)]
     elseif e.head === :let
-        if nargs >= 1 && !(e.args[1] isa Expr && e.args[1].head === :block)
-            child_exprs[1] = Expr(:block, e.args[1])
+        if nargs >= 1
+            a1,_ = unwrap_esc(e.args[1])
+            if !(a1 isa Expr && a1.head === :block)
+                child_exprs[1] = Expr(:block, e.args[1])
+            end
         end
     elseif e.head === :struct
         e.args[1] && (st_flags |= JS.MUTABLE_FLAG)
@@ -404,6 +440,12 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
         st_k = K"latestworld_if_toplevel"
     elseif e.head === Symbol("hygienic-scope")
         st_k = K"hygienic_scope"
+    elseif e.head === :escape
+        if length(e.args) == 1 && unwrap_esc_(e.args[1]) isa LineNumberNode
+            # escape containing only a LineNumberNode will become empty and
+            # thus must be removed before lowering sees it.
+            st_k = K"TOMBSTONE"
+        end
     elseif e.head === :meta
         # Messy and undocumented.  Only sometimes we want a K"meta".
         @assert e.args[1] isa Symbol
@@ -490,10 +532,12 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
     end
 
     #---------------------------------------------------------------------------
-    # Throw if this script isn't complete.  Finally, insert a new node into the
+    # Throw if this function isn't complete.  Finally, insert a new node into the
     # graph and recurse on child_exprs
     if st_k === K"None"
         error("Unknown expr head at $src: `$(e.head)`\n$(sprint(dump, e))")
+    elseif st_k === K"TOMBSTONE"
+        return nothing, src
     end
 
     st_id = _insert_tree_node(graph, st_k, src, st_flags; st_attrs...)
@@ -503,7 +547,6 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
     if isnothing(child_exprs)
         return st_id, src
     else
-        setflags!(graph, st_id, st_flags)
         st_child_ids, last_src = _insert_child_exprs(child_exprs, graph, src)
         setchildren!(graph, st_id, st_child_ids)
         return st_id, last_src
@@ -519,7 +562,9 @@ function _insert_child_exprs(child_exprs::Vector{Any}, graph::SyntaxGraph,
             last_src = c
         else
             (c_id, c_src) = _insert_convert_expr(c, graph, last_src)
-            push!(st_child_ids, c_id)
+            if !isnothing(c_id)
+                push!(st_child_ids, c_id)
+            end
             last_src = something(c_src, src)
         end
     end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -266,11 +266,13 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
                 child_exprs[1] = a1_esc(Expr(:(.), a1.args[1],
                                              Expr(:MacroName, a12_esc(a12.value))))
             end
-        elseif a1 isa GlobalRef
+        elseif a1 isa GlobalRef && a1.mod === Core
             # TODO (maybe): syntax-introduced macrocalls are listed here for
             # reference.  We probably don't need to convert these.
             if a1.name === Symbol("@cmd")
             elseif a1.name === Symbol("@doc")
+                st_k = K"doc"
+                child_exprs = child_exprs[2:end]
             elseif a1.name === Symbol("@int128_str")
             elseif a1.name === Symbol("@int128_str")
             elseif a1.name === Symbol("@big_str")

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -310,8 +310,21 @@ const JL = JuliaLowering
         ]
 
         for p in programs
-            @testset "`$p`" begin
+            @testset "`$(repr(p))`" begin
                 st_good = JS.parsestmt(JL.SyntaxTree, p; ignore_errors=true)
+                st_test = JL.expr_to_syntaxtree(Expr(st_good))
+                @test st_roughly_equal(;st_good, st_test)
+            end
+        end
+
+        # toplevel has a special parsing mode where docstrings and a couple of
+        # other things are enabled
+        toplevel_programs = [
+            "\"docstr\"\nthing_to_be_documented",
+        ]
+        for p in toplevel_programs
+            @testset "`$(repr(p))`" begin
+                st_good = JS.parseall(JL.SyntaxTree, p; ignore_errors=true)
                 st_test = JL.expr_to_syntaxtree(Expr(st_good))
                 @test st_roughly_equal(;st_good, st_test)
             end

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -302,6 +302,11 @@ const JL = JuliaLowering
             "import A",
             "A.x",
             "A.\$x",
+            "try x catch e; y end",
+            "try x finally y end",
+            "try x catch e; y finally z end",
+            "try x catch e; y else z end",
+            "try x catch e; y else z finally w end",
         ]
 
         for p in programs
@@ -364,17 +369,22 @@ const JL = JuliaLowering
         st = JuliaLowering.expr_to_syntaxtree(ex, LineNumberNode(1))
 
         # sanity: ensure we're testing the tree we expect
-        @test kind(st) === K"block"
-        @test kind(st[1]) === K"try"
-        @test kind(st[1][1]) === K"block"
-        @test kind(st[1][1][1]) === K"Identifier" && st[1][1][1].name_val === "maybe"
-        @test kind(st[1][1][2]) === K"Identifier" && st[1][1][2].name_val === "lots"
-        @test kind(st[1][1][3]) === K"Identifier" && st[1][1][3].name_val === "of"
-        @test kind(st[1][1][4]) === K"Identifier" && st[1][1][4].name_val === "lines"
-        @test kind(st[1][2]) === K"catch"
-        @test kind(st[1][2][1]) === K"Identifier" && st[1][2][1].name_val === "exc"
-        @test kind(st[1][2][2]) === K"block"
-        @test kind(st[1][2][2][1]) === K"Identifier" && st[1][2][2][1].name_val === "y"
+        @test st ≈ @ast_ [K"block"
+            [K"try"
+                [K"block"
+                    "maybe"::K"Identifier"
+                    "lots"::K"Identifier"
+                    "of"::K"Identifier"
+                    "lines"::K"Identifier"
+                ]
+                [K"catch"
+                    "exc"::K"Identifier"
+                    [K"block"
+                        "y"::K"Identifier"
+                    ]
+                ]
+            ]
+        ]
 
         @test let lnn = st.source;             lnn isa LineNumberNode && lnn.line === 1; end
         @test let lnn = st[1].source;          lnn isa LineNumberNode && lnn.line === 2; end
@@ -387,6 +397,205 @@ const JL = JuliaLowering
         @test let lnn = st[1][2][1].source;    lnn isa LineNumberNode && lnn.line === 6; end
         @test let lnn = st[1][2][2].source;    lnn isa LineNumberNode && lnn.line === 6; end
         @test let lnn = st[1][2][2][1].source; lnn isa LineNumberNode && lnn.line === 8; end
+
+        st_shortfunc = JuliaLowering.expr_to_syntaxtree(
+            Expr(:block,
+                 LineNumberNode(11),
+                 Expr(:(=),
+                      Expr(:call, :f),
+                      :body))
+        )
+        @test st_shortfunc ≈ @ast_ [K"block"
+            [K"function"
+                [K"call" "f"::K"Identifier"]
+                "body"::K"Identifier"
+            ]
+        ]
+        @test let lnn = st_shortfunc[1][1].source; lnn isa LineNumberNode && lnn.line === 11; end
+
+        st_shortfunc_2 = JuliaLowering.expr_to_syntaxtree(
+            Expr(:block,
+                 LineNumberNode(11),
+                 Expr(:(=),
+                      Expr(:call, :f),
+                      Expr(:block,
+                         LineNumberNode(22),
+                         :body)))
+        )
+        @test st_shortfunc_2 ≈ @ast_ [K"block"
+            [K"function"
+                [K"call" "f"::K"Identifier"]
+                "body"::K"Identifier"
+            ]
+        ]
+        @test let lnn = st_shortfunc_2[1][1].source; lnn isa LineNumberNode && lnn.line === 22; end
+    end
+
+    @testset "`Expr(:escape)` handling" begin
+        # `x.y` with quoted y escaped (this esc does nothing, but is permitted by
+        # the existing expander)
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:(.), :x, esc(QuoteNode(:y)))) ≈
+            @ast_ [K"."
+                "x"::K"Identifier"
+                [K"escape"
+                    "y"::K"Identifier"
+                ]
+            ]
+
+        # `f(x; y)` with parameters escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:call, :f, esc(Expr(:parameters, :y)), :x)) ≈
+            @ast_ [K"call"
+                "f"::K"Identifier"
+                "x"::K"Identifier"
+                [K"escape"
+                    [K"parameters"
+                        "y"::K"Identifier"
+                    ]
+                ]
+            ]
+
+        # `.+(x)` with operator escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:call, esc(Symbol(".+")), :x)) ≈
+            @ast_ [K"dotcall"
+                [K"escape" "+"::K"Identifier"]
+                "x"::K"Identifier"
+            ]
+
+        # `let x \n end` with binding escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:let, esc(:x), Expr(:block))) ≈
+            @ast_ [K"let"
+                [K"block" [K"escape" "x"::K"Identifier"]]
+                [K"block"]
+            ]
+
+        # `x .+ y` with .+ escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:comparison, :x, esc(Symbol(".+")), :y)) ≈
+            @ast_ [K"comparison"
+                "x"::K"Identifier"
+                [K"." 
+                    [K"escape" "+"::K"Identifier"]
+                ]
+                "y"::K"Identifier"
+            ]
+
+        # `@mac x` with macro name escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:macrocall, esc(Symbol("@mac")), nothing, :x)) ≈
+            @ast_ [K"macrocall"
+                [K"escape" "@mac"::K"MacroName"]
+                "x"::K"Identifier"
+            ]
+
+        # `@mac x` with macro name escaped
+        @test JuliaLowering.expr_to_syntaxtree(
+            Expr(:macrocall, esc(Expr(:(.), :A, QuoteNode(Symbol("@mac")))), nothing, :x)
+        ) ≈ @ast_ [K"macrocall"
+            [K"escape"
+                [K"."
+                    "A"::K"Identifier"
+                    "@mac"::K"MacroName"
+                ]
+            ]
+            "x"::K"Identifier"
+        ]
+
+        # `x where y`
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:where, :x, esc(:y))) ≈
+            @ast_ [K"where"
+                "x"::K"Identifier"
+                [K"braces"
+                    [K"escape" "y"::K"Identifier"]
+                ]
+            ]
+
+        # Some weirdly placed esc's in try-catch
+        # `try body1 catch exc \n end`
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:try, :body1, :exc, esc(false))) ≈
+            @ast_ [K"try"
+                "body1"::K"Identifier"
+                [K"catch"
+                    "exc"::K"Identifier"
+                    "nothing"::K"core"
+                ]
+            ]
+        # `try body1 catch \n body2 \n end`
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:try, :body1, esc(false), :body2)) ≈
+            @ast_ [K"try"
+                "body1"::K"Identifier"
+                [K"catch"
+                    ""::K"Placeholder"
+                    "body2"::K"Identifier"
+                ]
+            ]
+        # `try body1 finally body2 end`
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:try, :body1, esc(false), esc(false), :body2)) ≈
+            @ast_ [K"try"
+                "body1"::K"Identifier"
+                [K"finally"
+                    "body2"::K"Identifier"
+                ]
+            ]
+
+        # `try body1 finally body2 end`
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:try, :body1, esc(false), esc(false), esc(false), :body2)) ≈
+            @ast_ [K"try"
+                "body1"::K"Identifier"
+                [K"else"
+                    "body2"::K"Identifier"
+                ]
+            ]
+
+        # [x ;;; y] with dim escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:ncat, esc(3), :x, :y)) ≈
+            @ast_ [K"ncat"(syntax_flags=JuliaSyntax.set_numeric_flags(3))
+                "x"::K"Identifier"
+                "y"::K"Identifier"
+            ]
+
+        # T[x ;;; y] with dim escaped
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:typed_ncat, :T, esc(3), :x, :y)) ≈
+            @ast_ [K"typed_ncat"(syntax_flags=JuliaSyntax.set_numeric_flags(3))
+                "T"::K"Identifier"
+                "x"::K"Identifier"
+                "y"::K"Identifier"
+            ]
+
+        # One example of hygienic-scope (handled with the same mechanism as escape)
+        @test JuliaLowering.expr_to_syntaxtree(
+            Expr(:macrocall, Expr(:var"hygienic-scope", Symbol("@mac"), :other, :args), nothing, :x)) ≈
+            @ast_ [K"macrocall"
+                [K"hygienic_scope"
+                    "@mac"::K"MacroName"
+                    "other"::K"Identifier" # (<- normally a Module)
+                    "args"::K"Identifier" # (<- normally a LineNumberNode)
+                ]
+                "x"::K"Identifier"
+            ]
+
+        # One example of double escaping
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:macrocall, esc(esc(Symbol("@mac"))), nothing, :x)) ≈
+            @ast_ [K"macrocall"
+                [K"escape" [K"escape" "@mac"::K"MacroName"]]
+                "x"::K"Identifier"
+            ]
+
+        # One example of nested escape and hygienic-scope
+        @test JuliaLowering.expr_to_syntaxtree(
+            Expr(:macrocall,
+                 Expr(:var"hygienic-scope", esc(Symbol("@mac")), :other, :args),
+                 nothing,
+                 :x)) ≈
+            @ast_ [K"macrocall"
+                [K"hygienic_scope"
+                    [K"escape"
+                        "@mac"::K"MacroName"
+                    ]
+                    "other"::K"Identifier" # (<- normally a Module)
+                    "args"::K"Identifier" # (<- normally a LineNumberNode)
+                ]
+                "x"::K"Identifier"
+            ]
+
+        @test JuliaLowering.expr_to_syntaxtree(Expr(:block, esc(LineNumberNode(1)))) ≈ @ast_ [K"block"]
 
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -49,13 +49,13 @@ function ≈(ex1, ex2)
         return false
     end
     if is_leaf(ex1)
+        return get(ex1, :value,    nothing) == get(ex2, :value,    nothing) &&
+               get(ex1, :name_val, nothing) == get(ex2, :name_val, nothing)
+    else
         if numchildren(ex1) != numchildren(ex2)
             return false
         end
         return all(c1 ≈ c2 for (c1,c2) in zip(children(ex1), children(ex2)))
-    else
-        return get(ex1, :value,    nothing) == get(ex2, :value,    nothing) &&
-               get(ex1, :name_val, nothing) == get(ex2, :name_val, nothing)
     end
 end
 


### PR DESCRIPTION
The manual `esc()` system allows macros to emit `Expr(:escape)` in
almost any location within the AST so we generally need to unwrap and
rewrap such escapes when pattern matching the incoming `Expr` tree
during conversion to `SyntaxTree`.

Also fix some other issues found during testing of these changes:
* `finally` block shouldn't be added if it's set to `false` in the
  Expr form
* The test implementation of `≈` for ASTs was very buggy due to a
  previous refactor. Fix this.
* Expr form allows any callable object as the macro name, so we can't
  really reject much here - remove the test for that.
* Do not format Expr to string as part of conversion - this could be
  expensive and also fails in Base in some strange cases of esc()
  placement (eg, ncat dim argument)
* Filter out `K"TOMBSTONE"` inside `expr_to_syntaxtree()` because this
  can end up in value position which is an error later in linear IR
  generation.

I tacked on a change to convert `@ doc` -> `K"doc"` here as well
so that we can use the improved documentation lowering rather
than the doc macro's partial reimplementation of lowering.