### PR TITLE
Fix for Expr->SyntaxTree conversion with interpolated field name

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -256,7 +256,7 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
             st_k = K"dotcall"
             tuple_exprs = collect_expr_parameters(a2, 1)
             child_exprs = pushfirst!(tuple_exprs, e.args[1])
-        elseif a2 isa QuoteNode && a2.value isa Symbol
+        elseif a2 isa QuoteNode
             child_exprs[2] = a2.value
         end
     elseif e.head === :for

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -300,6 +300,8 @@ const JL = JuliaLowering
             "module A end",
             "baremodule A end",
             "import A",
+            "A.x",
+            "A.\$x",
         ]
 
         for p in programs

--- a/test/quoting.jl
+++ b/test/quoting.jl
@@ -88,7 +88,7 @@ end
 ex = JuliaLowering.include_string(test_mod, """
 let
     field_name = :(a)
-    :(a.\$field_name)
+    :(x.\$field_name)
 end
 """)
 @test kind(ex[2]) == K"Identifier"


### PR DESCRIPTION
The second argument of `K"."` is implicitly `K"inert"` in our representation so we need to remove `QuoteNode` whenever it's present in the Expr form.

Fix #53