### PR TITLE
Custom cmd macro support + tests for cmd and string macros

### DIFF
--- a/src/ast.jl
+++ b/src/ast.jl
@@ -143,7 +143,7 @@ function makeleaf(ctx, srcref, k::Kind, value; kws...)
     graph = syntax_graph(ctx)
     if k == K"Identifier" || k == K"core" || k == K"top" || k == K"Symbol" ||
             k == K"globalref" || k == K"Placeholder" || k == K"MacroName" ||
-            k == "StringMacroName" || k == K"CmdMacroName"
+            k == K"StringMacroName" || k == K"CmdMacroName"
         makeleaf(graph, srcref, k; name_val=value, kws...)
     elseif k == K"BindingId"
         makeleaf(graph, srcref, k; var_id=value, kws...)

--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -334,7 +334,7 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
             layerid = get(ex, :scope_layer, current_layer_id(ctx))
             makeleaf(ctx, ex, ex, kind=K"Identifier", scope_layer=layerid)
         end
-    elseif k == K"Identifier" || k == K"MacroName" || k == K"StringMacroName"
+    elseif k == K"Identifier" || k == K"MacroName" || k == K"StringMacroName" || k == K"CmdMacroName"
         layerid = get(ex, :scope_layer, current_layer_id(ctx))
         makeleaf(ctx, ex, ex, kind=K"Identifier", scope_layer=layerid)
     elseif k == K"var" || k == K"char" || k == K"parens"

--- a/test/macros_ir.jl
+++ b/test/macros_ir.jl
@@ -15,6 +15,22 @@ module MacroMethods
     end
 end
 
+macro strmac_str(ex, suff=nothing)
+    s = "$(ex[1].value) from strmac"
+    if !isnothing(suff)
+        s = "$s with suffix $(suff.value)"
+    end
+    s
+end
+
+macro cmdmac_cmd(ex, suff=nothing)
+    s = "$(ex[1].value) from cmdmac"
+    if !isnothing(suff)
+        s = "$s with suffix $(suff.value)"
+    end
+    s
+end
+
 #*******************************************************************************
 ########################################
 # Simple macro
@@ -146,4 +162,28 @@ Suggestion: check for spelling errors or missing imports.
 4   (call core.tuple %₂ %₃)
 5   (call %₁ %₄)
 6   (return %₅)
+
+########################################
+# Simple string macro
+strmac"hello"
+#---------------------
+1   (return "hello from strmac")
+
+########################################
+# String macro with suffix
+strmac"hello"blah
+#---------------------
+1   (return "hello from strmac with suffix blah")
+
+########################################
+# Simple cmd macro
+cmdmac`hello`
+#---------------------
+1   (return "hello from cmdmac")
+
+########################################
+# Cmd macro with suffix
+cmdmac`hello`12345
+#---------------------
+1   (return "hello from cmdmac with suffix 12345")
 


### PR DESCRIPTION
Apparently we didn't support lowering of custom cmd macros. Fixed this and added some tests.