### PR TITLE
Implement include() with Base.IncludeInto and similarly for eval

### DIFF
--- a/src/desugaring.jl
+++ b/src/desugaring.jl
@@ -4251,51 +4251,25 @@ function expand_module(ctx, ex::SyntaxTree)
     std_defs = if !has_flags(ex, JuliaSyntax.BARE_MODULE_FLAG)
         @ast ctx (@HERE) [
             K"block"
-            [K"using"(@HERE)
+            [K"using"
                 [K"importpath"
                     "Base"           ::K"Identifier"
                 ]
             ]
-            [K"function"(@HERE)
+            [K"const" [K"="
+                "eval"::K"Identifier"
                 [K"call"
-                    "eval"           ::K"Identifier"
-                    "x"              ::K"Identifier"
+                    "EvalInto"::K"core"
+                    modname::K"Identifier"
                 ]
+            ]]
+            [K"const" [K"="
+                "include"::K"Identifier"
                 [K"call"
-                    "eval"           ::K"core"
-                    modname          ::K"Identifier"
-                    "x"              ::K"Identifier"
+                    "IncludeInto"::K"top"
+                    modname::K"Identifier"
                 ]
-            ]
-            [K"function"(@HERE)
-                [K"call"
-                    "include"        ::K"Identifier"
-                    "x"              ::K"Identifier"
-                ]
-                [K"call"
-                    "_call_latest"   ::K"core"
-                    "include"        ::K"top"
-                    modname          ::K"Identifier"
-                    "x"              ::K"Identifier"
-                ]
-            ]
-            [K"function"(@HERE)
-                [K"call"
-                    "include"        ::K"Identifier"
-                    [K"::"
-                        "mapexpr"    ::K"Identifier"
-                        "Function"   ::K"top"
-                    ]
-                    "x"              ::K"Identifier"
-                ]
-                [K"call"
-                    "_call_latest"   ::K"core"
-                    "include"        ::K"top"
-                    "mapexpr"        ::K"Identifier"
-                    modname          ::K"Identifier"
-                    "x"              ::K"Identifier"
-                ]
-            ]
+            ]]
         ]
     end
 

--- a/src/desugaring.jl
+++ b/src/desugaring.jl
@@ -4248,30 +4248,7 @@ function expand_module(ctx, ex::SyntaxTree)
     @chk kind(modname_ex) == K"Identifier"
     modname = modname_ex.name_val
 
-    std_defs = if !has_flags(ex, JuliaSyntax.BARE_MODULE_FLAG)
-        @ast ctx (@HERE) [
-            K"block"
-            [K"using"
-                [K"importpath"
-                    "Base"           ::K"Identifier"
-                ]
-            ]
-            [K"const" [K"="
-                "eval"::K"Identifier"
-                [K"call"
-                    "EvalInto"::K"core"
-                    modname::K"Identifier"
-                ]
-            ]]
-            [K"const" [K"="
-                "include"::K"Identifier"
-                [K"call"
-                    "IncludeInto"::K"top"
-                    modname::K"Identifier"
-                ]
-            ]]
-        ]
-    end
+    std_defs = !has_flags(ex, JuliaSyntax.BARE_MODULE_FLAG)
 
     body = ex[2]
     @chk kind(body) == K"block"
@@ -4285,10 +4262,10 @@ function expand_module(ctx, ex::SyntaxTree)
             eval_module           ::K"Value"
             ctx.mod               ::K"Value"
             modname               ::K"String"
+            std_defs              ::K"Bool"
             ctx.expr_compat_mode  ::K"Bool"
             [K"inert"(body)
                 [K"toplevel"
-                    std_defs
                     children(body)...
                 ]
             ]

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -189,7 +189,7 @@ module Mod
     stmts
 end
 #---------------------
-1   (call JuliaLowering.eval_module TestMod "Mod" false (inert (toplevel (block (using (importpath Base)) (const (= eval (call core.EvalInto Mod))) (const (= include (call top.IncludeInto Mod)))) body stmts)))
+1   (call JuliaLowering.eval_module TestMod "Mod" true false (inert (toplevel body stmts)))
 2   (return %₁)
 
 ########################################
@@ -199,7 +199,7 @@ baremodule BareMod
     stmts
 end
 #---------------------
-1   (call JuliaLowering.eval_module TestMod "BareMod" false (inert (toplevel body stmts)))
+1   (call JuliaLowering.eval_module TestMod "BareMod" false false (inert (toplevel body stmts)))
 2   (return %₁)
 
 ########################################

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -183,6 +183,26 @@ LoweringError:
 #       └─┘ ── Invalid named tuple element
 
 ########################################
+# Module lowering
+module Mod
+    body
+    stmts
+end
+#---------------------
+1   (call JuliaLowering.eval_module TestMod "Mod" false (inert (toplevel (block (using (importpath Base)) (const (= eval (call core.EvalInto Mod))) (const (= include (call top.IncludeInto Mod)))) body stmts)))
+2   (return %₁)
+
+########################################
+# Bare module lowering
+baremodule BareMod
+    body
+    stmts
+end
+#---------------------
+1   (call JuliaLowering.eval_module TestMod "BareMod" false (inert (toplevel body stmts)))
+2   (return %₁)
+
+########################################
 # Error: Modules not allowed in local scope
 let
     module C

--- a/test/modules.jl
+++ b/test/modules.jl
@@ -11,10 +11,11 @@ end
 """, "module_test")
 @test A isa Module
 @test A.g() == "hi"
-@test A.include isa Function
+@test A.include isa Base.IncludeInto
+@test A.eval isa Core.EvalInto
 @test A.Base === Base
-@test A.eval(:(x = -1)) == -1
-@test A.x == -1
+@test A.eval(:(x = -2)) == -2
+@test A.x == -2
 
 B = JuliaLowering.include_string(test_mod, """
 baremodule B
@@ -22,6 +23,7 @@ end
 """, "baremodule_test")
 @test B.Core === Core
 @test !isdefined(B, :include)
+@test !isdefined(B, :eval)
 @test !isdefined(B, :Base)
 
 # modules allowed in nested code in global scope


### PR DESCRIPTION
Adopt the changes from https://github.com/JuliaLang/julia/pull/55949 to define module-local include / eval in terms of `Base.IncludeInto` and `Core.EvalInto`.