### PR TITLE
Separate `JuliaLowering.eval()` from `Core.eval()`

### DIFF
--- a/src/JuliaLowering.jl
+++ b/src/JuliaLowering.jl
@@ -1,11 +1,10 @@
+# Use a baremodule because we're implementing `include` and `eval`
 baremodule JuliaLowering
 
-# ^ Use baremodule because we're implementing `Base.include` and `Core.eval`.
 using Base
 # We define a separate _include() for use in this module to avoid mixing method
 # tables with the public `JuliaLowering.include()` API
 const _include = Base.IncludeInto(JuliaLowering)
-using Core: eval
 
 if parentmodule(JuliaLowering) === Base
     using Base.JuliaSyntax

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -59,7 +59,7 @@ else
             end)
         end
 
-        eval(@__MODULE__, code)
+        Core.eval(@__MODULE__, code)
     end
 end
 
@@ -349,7 +349,7 @@ end
 
 #-------------------------------------------------------------------------------
 # Our version of eval takes our own data structures
-@fzone "JL: eval" function Core.eval(mod::Module, ex::SyntaxTree; expr_compat_mode::Bool=false)
+@fzone "JL: eval" function eval(mod::Module, ex::SyntaxTree; expr_compat_mode::Bool=false)
     k = kind(ex)
     if k == K"toplevel"
         x = nothing
@@ -359,8 +359,8 @@ end
         return x
     end
     linear_ir = lower(mod, ex; expr_compat_mode)
-    expr_form = to_lowered_expr(mod, linear_ir)
-    eval(mod, expr_form)
+    thunk = to_lowered_expr(mod, linear_ir)
+    Core.eval(mod, thunk)
 end
 
 """

--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -149,7 +149,7 @@ function eval_macro_name(ctx::MacroExpansionContext, mctx::MacroContext, ex::Syn
     mod = current_layer(ctx).mod
     expr_form = to_lowered_expr(mod, ex5)
     try
-        eval(mod, expr_form)
+        Core.eval(mod, expr_form)
     catch err
         throw(MacroExpansionError(mctx, ex, "Macro not found", :all, err))
     end

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -229,7 +229,7 @@ function eval_module(parentmod, modname, expr_compat_mode, body)
     # mod = @ccall jl_new_module(Symbol(modname)::Symbol, parentmod::Module)::Any
     # ...
     name = Symbol(modname)
-    eval(parentmod, :(
+    Core.eval(parentmod, :(
         baremodule $name
             $eval($name, $body; expr_compat_mode=$expr_compat_mode)
         end
@@ -246,7 +246,7 @@ function eval_import(imported::Bool, to::Module, from::Union{Expr, Nothing}, pat
         ex = isnothing(from) ?
             Expr(head, paths...) :
             Expr(head, Expr(Symbol(":"), from, paths...))
-        Base.eval(to, ex)
+        Core.eval(to, ex)
     end
 end
 
@@ -254,13 +254,13 @@ function eval_using(to::Module, path::Expr)
     if _Base_has_eval_import
         Base._eval_using(to, path)
     else
-        Base.eval(to, Expr(:using, path))
+        Core.eval(to, Expr(:using, path))
     end
 end
 
 function eval_public(mod::Module, is_exported::Bool, identifiers)
     # symbol jl_module_public is no longer exported as of #57765
-    eval(mod, Expr((is_exported ? :export : :public), map(Symbol, identifiers)...))
+    Core.eval(mod, Expr((is_exported ? :export : :public), map(Symbol, identifiers)...))
 end
 
 #--------------------------------------------------

--- a/test/scopes.jl
+++ b/test/scopes.jl
@@ -66,7 +66,7 @@ function wrapscope(ex, scope_type)
 end
 
 assign_z_2 = parsestmt(SyntaxTree, "begin z = 2 end", filename="foo.jl")
-JuliaLowering.eval(test_mod, :(z=1))
+Base.eval(test_mod, :(z=1))
 @test test_mod.z == 1
 # neutral (eg, for loops) and hard (eg, let) scopes create a new binding for z
 JuliaLowering.eval(test_mod, wrapscope(assign_z_2, :neutral))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -163,7 +163,7 @@ function format_ir_for_test(mod, case)
         if kind(ex) == K"macrocall" && kind(ex[1]) == K"MacroName" && ex[1].name_val == "@ast_"
             # Total hack, until @ast_ can be implemented in terms of new-style
             # macros.
-            ex = JuliaLowering.eval(mod, Expr(ex))
+            ex = Base.eval(mod, Expr(ex))
         end
         x = JuliaLowering.lower(mod, ex)
         if case.expect_error


### PR DESCRIPTION
Overloading `Core.eval()` with `SyntaxTree` was a cute trick but I believe it causes invalidations in the include machinery (Base.IncludeInto as mentioned in #65) and doesn't really integrate JuliaLowering properly because it doesn't let us implement `Core.eval(::Module, ::Expr)`. Instead we need hooks for this.

For now, implementing `eval` as a separate function helps quite a lot with precompile time - about a 15% reduction on my machine.