### PR TITLE
Fix BoundsError with mixed file provenance not caused by macros

### DIFF
--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -17,6 +17,11 @@ const JL = JuliaLowering
             val = Core.eval(test_mod, out[1])
             @test val == [2,3,4]
         end
+
+        # file argument mismatch with embedded linenumbernodes shouldn't crash
+        ex = Expr(:block, LineNumberNode(111), :(x = 1), LineNumberNode(222), :(x + 1))
+        lwr = JuliaLowering.core_lowering_hook(ex, test_mod, "foo.jl", 333)[1]
+        @test Core.eval(test_mod, lwr) === 2
     end
 
     if isdefined(Core, :_lower)


### PR DESCRIPTION
Was causing several stdlib failures.  MWE:
```
julia> ex = Meta.parse("begin
       x = 111
       x = 222
       end")

julia> JuliaLowering.core_lowering_hook(ex, Main, "foo.jl", 100)
```

If `core_lowering_hook` is given one filename (e.g. "none" from `@eval`), but
     some part of the expression contains LineNumberNodes with a different
     filename, we trigger the "inlined macro-expansion" logic in the debuginfo
     generator, which assumes new filenames are from new macro expansions atop
     the old filename.  The violated invariant is that the list of files in this
     statement's flattened provenance shares some prefix with the last
     statement's list of files.

This fix assumes there is some base file that all statements share, and
     normalizes different base filenames to the first it sees.

Aside: Not sure if this stack logic is 100% correct given that two adjacent
     statements can share arbitrarily many file stack entries despite being from
     different macro expansions.  I'm also unsure if `flattened_provenance` is 
     intended to guarantee the order of its result.