### PR TITLE
Add `:no_constprop` as expected `Expr(:meta, ...)` argument

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -472,7 +472,7 @@ function _insert_convert_expr(@nospecialize(e), graph::SyntaxGraph, src::SourceA
             end
         elseif e.args[1] in (:inline, :noinline, :generated, :generated_only,
                              :max_methods, :optlevel, :toplevel, :push_loc, :pop_loc,
-                             :aggressive_constprop, :specialize, :compile, :infer,
+                             :no_constprop, :aggressive_constprop, :specialize, :compile, :infer,
                              :nospecializeinfer, :force_compile, :doc)
             # TODO: Some need to be handled in lowering
             child_exprs[1] = Expr(:quoted_symbol, e.args[1])


### PR DESCRIPTION
This came up on many examples when using `@report_trim` from https://github.com/aviatesk/JET.jl/pull/753