### PR TITLE
Fix quoted property access syntax (e.g., `Core.:(!==)`)

### DIFF
--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -458,7 +458,13 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
     elseif k == K"module" || k == K"toplevel" || k == K"inert"
         ex
     elseif k == K"." && numchildren(ex) == 2
-        e2 = expand_forms_1(ctx, ex[2])
+        # Handle quoted property access like `x.:(foo)` or `Core.:(!==)`
+        # Unwrap the quote to get the identifier before expansion
+        rhs = ex[2]
+        if kind(rhs) == K"quote" && numchildren(rhs) == 1
+            rhs = rhs[1]
+        end
+        e2 = expand_forms_1(ctx, rhs)
         if kind(e2) == K"Identifier" || kind(e2) == K"Placeholder"
             # FIXME: Do the K"Symbol" transformation in the parser??
             e2 = @ast ctx e2 e2=>K"Symbol"

--- a/test/quoting.jl
+++ b/test/quoting.jl
@@ -94,6 +94,15 @@ end
 @test kind(ex[2]) == K"Identifier"
 @test ex[2].name_val == "a"
 
+# Test quoted property access syntax like `Core.:(foo)` and `Core.:(!==)`
+@test JuliaLowering.include_string(test_mod, """
+    x = (a=1, b=2)
+    x.:(a)
+""") == 1
+@test JuliaLowering.include_string(test_mod, """
+    Core.:(!==)
+""") === (!==)
+
 # interpolations at multiple depths
 ex = JuliaLowering.include_string(test_mod, raw"""
 let

--- a/test/quoting_ir.jl
+++ b/test/quoting_ir.jl
@@ -43,3 +43,33 @@ quote
 #    └┘ ── `$` expression outside string or quote block
 end
 
+########################################
+# Quoted property access with identifier
+Core.:(foo)
+#---------------------
+1   TestMod.Core
+2   (call top.getproperty %₁ :foo)
+3   (return %₂)
+
+########################################
+# Quoted property access with operator
+Core.:(!==)
+#---------------------
+1   TestMod.Core
+2   (call top.getproperty %₁ :!==)
+3   (return %₂)
+
+########################################
+# Quoted property access on variable
+let
+    x = (a=1, b=2)
+    x.:(a)
+end
+#---------------------
+1   (call core.tuple :a :b)
+2   (call core.apply_type core.NamedTuple %₁)
+3   (call core.tuple 1 2)
+4   (= slot₁/x (call %₂ %₃))
+5   slot₁/x
+6   (call top.getproperty %₅ :a)
+7   (return %₆)


### PR DESCRIPTION
Handle `K"quote"` nodes in property access during macro expansion by unwrapping them before processing. This allows syntax like `Core.:(!==)` to lower correctly, matching the behavior of `Meta.lower`.