### PR TITLE
Add support for `global`/`local` declarations for functions

### DIFF
--- a/test/decls.jl
+++ b/test/decls.jl
@@ -97,4 +97,93 @@ end
 # Unsupported for now
 @test_throws LoweringError JuliaLowering.include_string(test_mod, "const a,b,c = 1,2,3")
 
+@testset "global function in let" begin
+    # Basic case: short form function syntax
+    @test JuliaLowering.include_string(test_mod, """
+    let x = 42
+        global getx1() = x
+    end
+    """) == test_mod.getx1
+    @test test_mod.getx1() === 42
+
+    # Long form function syntax
+    @test JuliaLowering.include_string(test_mod, """
+    let y = 100
+        global function gety1()
+            y
+        end
+    end
+    """) == test_mod.gety1
+    @test test_mod.gety1() === 100
+
+    # Multiple global functions in same let
+    @test JuliaLowering.include_string(test_mod, """
+    let val = 7
+        global getval1() = val
+        global setval1(v) = (val = v)
+    end
+    """) == test_mod.setval1
+    @test test_mod.getval1() === 7
+    test_mod.setval1(20)
+    @test test_mod.getval1() === 20
+
+    # Type-qualified function
+    JuliaLowering.include_string(test_mod, """
+    struct TestCallable1 end
+    let x = 99
+        global (::TestCallable1)() = x
+    end
+    """)
+    @test test_mod.TestCallable1()() === 99
+
+    # Function with where clause
+    @test JuliaLowering.include_string(test_mod, """
+    let data = [1,2,3]
+        global getdata1(::Type{T}) where T = T.(data)
+    end
+    """) == test_mod.getdata1
+    @test test_mod.getdata1(Float64) == [1.0, 2.0, 3.0]
+end
+
+@testset "local function declaration" begin
+    @test JuliaLowering.include_string(test_mod, """
+    let
+        local f() = 42
+        f()
+    end
+    """) === 42
+
+    # Local function should not leak out
+    @test !Base.isdefinedglobal(test_mod, :f)
+end
+
+# Qualified names should work (no declaration added)
+@testset "qualified function names" begin
+    JuliaLowering.include_string(test_mod, """
+    module TestMod1
+        f() = 1
+    end
+    """)
+
+    @test JuliaLowering.include_string(test_mod, """
+    global TestMod1.f(x::Int) = x + 1
+    """) === nothing
+    @test test_mod.TestMod1.f(5) === 6
+
+    @test JuliaLowering.include_string(test_mod, """
+    let
+        global TestMod1.f(x::Float64) = x + 1
+    end
+    """) === nothing
+    @test test_mod.TestMod1.f(5.0) === 6.0
+end
+
+# Error cases
+@test_throws LoweringError JuliaLowering.include_string(test_mod, """
+let
+    local func(x) = x
+    global func(x) = x
+end
+""")
+
 end


### PR DESCRIPTION
Allow function definitions with `global` and `local` declarations, enabling patterns like
```
let x = 1
    global f() = x
end
```

Fixes c42f/JuliaLowering.jl#28.