### PR TITLE
Attempt to define the AST

### DIFF
--- a/src/JuliaLowering.jl
+++ b/src/JuliaLowering.jl
@@ -37,6 +37,7 @@ _include("syntax_macros.jl")
 _include("eval.jl")
 _include("compat.jl")
 _include("hooks.jl")
+_include("validation.jl")
 
 function __init__()
     _register_kinds()

--- a/src/desugaring.jl
+++ b/src/desugaring.jl
@@ -4595,6 +4595,7 @@ end
 
 @fzone "JL: desugar" function expand_forms_2(ctx::MacroExpansionContext, ex::SyntaxTree)
     ctx1 = DesugaringContext(ctx, ctx.expr_compat_mode)
+    valid_st1_or_throw(ex)
     ex1 = expand_forms_2(ctx1, reparent(ctx1, ex))
     ctx1, ex1
 end

--- a/src/syntax_graph.jl
+++ b/src/syntax_graph.jl
@@ -817,3 +817,229 @@ end
 #     end
 #     out
 # end
+
+# TODO: forgot to support vcat (i.e. newlines in patterns currently require a
+# double-semicolon continuation)
+
+# TODO: SyntaxList pattern matching could take similar syntax and use most of
+# the same machinery
+
+raw"""
+Simple SyntaxTree pattern matching
+
+```
+@stm syntax_tree begin
+    pattern1 -> result1
+    (pattern2, when=cond2) -> result2
+    (pattern3, when=cond3, run=run3, when=cond4) -> result3
+    ...
+end
+```
+
+Returns the first result where its corresponding pattern matches `syntax_tree`
+and each extra `cond` is true.  Throws an error if no match is found.
+
+This macro (especially `when` and `run`) takes heavy inspiration from [Racket's
+pattern matching](https://docs.racket-lang.org/reference/match.html), but with a
+significantly less featureful pattern language.
+
+## Patterns
+
+A pattern is used as both a conditional (does this syntax tree have a certain
+structure?) and a `let` (bind trees to these names if so).  Each pattern uses a
+limited version of the @ast syntax:
+
+```
+<pattern> = <tree_identifier>
+          | [K"<kind>" <pattern>*]
+          | [K"<kind>" <pattern>* <list_identifier>... <pattern>*]
+
+# note "*" is the meta-operator meaning one or more, and "..." is literal
+```
+
+where a `[K"k" p1 p2 ps...]` form matches any tree with kind `k` and >=2
+children (bound to `p1` and `p2`), and `ps` is bound to the possibly-empty
+SyntaxList of children `3:end`.  Identifiers (except `_`) can't be re-used, but
+may check for some form of tree equivalence in a future implementation.
+
+## Extra conditions: `when`, `run`
+
+Like an escape hatch to the structure-matching mechanism.  `when=cond` requires
+`cond`'s value be `true` for this pattern to match.  `run=code` evaluates
+`code`, usually to bind variables.  For convenience, the value of `code` is
+bound to the local `run`, which can be opted out of by quoting `run`.
+
+`when` and `run` clauses may appear multiple times in any order after the
+pattern.  They are executed left-to-right, stopping if any `when=cond` evaluates
+to false.  These may not mutate the object being matched.
+
+## Scope of variables
+
+Every `(pattern, extras...) -> result` introduces a local scope.  Identifiers in
+the pattern are let-bound when evaluating `extras` and `result`. Any `extra` can
+introduce variables for use in later `extras` and `result`.  User code in
+`extras` and `result` can refer to outer variables.
+
+## Example
+
+```
+julia> st = JuliaSyntax.parsestmt(JuliaLowering.SyntaxTree, "function foo(x,y,z); x; end")
+julia> JuliaLowering.@stm st begin
+    [K"function" [K"call" fname args... [K"parameters" kws...]] body] ->
+        "has kwargs: $(kws)"
+    [K"function" fname] ->
+        "zero-method function $fname"
+    [K"function" [K"call" fname args...] body] ->
+        "normal function $fname"
+    ([K"=" [K"call" _...] _...], run=if_valid_get_args(st[1]), when=!isnothing(run)) ->
+        "deprecated call-equals form with args $run"
+    (_, run=show("printf debugging is great")) -> "something else"
+    _ -> "something else"
+end
+"normal function foo"
+```
+"""
+macro stm(st, pats)
+    _stm(__source__, st, pats; debug=false)
+end
+
+"Like `@stm`, but prints a trace during matching."
+macro stm_debug(st, pats)
+    _stm(__source__, st, pats; debug=true)
+end
+
+function _stm(line::LineNumberNode, st, pats; debug=false)
+    _stm_check_usage(pats)
+    # We leave most code untouched, so the user probably wants esc(output)
+    st_gs, result_gs = gensym("st"), gensym("result")
+    out_blk = Expr(:let,
+                   Expr(:block, :($st_gs = $st::SyntaxTree), :($result_gs = nothing)),
+                   Expr(:if, false, nothing))
+    needs_else = out_blk.args[2].args
+    for per in pats.args
+        per isa LineNumberNode && (line = per; continue)
+        p, extras, result = _stm_destruct_pat(Base.remove_linenums!(per))
+        # We need to let-bind patvars in both extras and the result, so result
+        # needs to live in the first argument of :if with the extra conditions.
+        e_check = Expr(:&&)
+        for (ek, ev) in extras
+            push!(e_check.args, ek === :when ? ev :
+                Expr(:block, ek === :run ? :(local run = $ev) : ev, true))
+        end
+        # final arg to e_check: successful match
+        push!(e_check.args, Expr(:block, line, :($result_gs = $result), true))
+        case = Expr(:elseif,
+            Expr(:&&, :(JuliaLowering._stm_matches($(Expr(:quote, p)), $st_gs, $debug)),
+                 Expr(:let, _stm_assigns(p, st_gs), e_check)),
+            result_gs)
+        push!(needs_else, case)
+        needs_else = needs_else[3].args
+    end
+    push!(needs_else, :(throw("No match found for $($st_gs) at $($(string(line)))")))
+    return esc(out_blk)
+end
+
+function _stm_destruct_pat(per)
+    pe, r = per.args[1:2]
+    return !Meta.isexpr(pe, :tuple) ? (pe, Tuple[], r) :
+        let extras = pe.args[2:end]
+            (pe.args[1], Tuple[(e.args[1], e.args[2]) for e in extras], r)
+        end
+end
+
+function _stm_matches(p::Union{Symbol, Expr}, st, debug=false, indent="")
+    if p isa Symbol
+        debug && printstyled(indent, "$p = $st\n"; color=:yellow)
+        return true
+    elseif Meta.isexpr(p, (:vect, :hcat))
+        p_kind = Kind(p.args[1].args[3])
+        kind_ok = p_kind === kind(st)
+        if !kind_ok
+            debug && printstyled(indent, "[kind]: $(kind(st))!=$p_kind\n"; color=:red)
+            return false
+        end
+        p_args = filter(e->!(e isa LineNumberNode), p.args)[2:end]
+        dots_i = findfirst(x->Meta.isexpr(x, :(...)), p_args)
+        dots_start = something(dots_i, length(p_args) + 1)
+        n_after = length(p_args) - dots_start
+        npats = dots_start + n_after
+        n_ok = (isnothing(dots_i) ? numchildren(st) === npats : numchildren(st) >= npats - 1)
+        if !n_ok
+            debug && printstyled(indent, "[numc]: $(numchildren(st))!=$npats\n"; color=:red)
+            return false
+        end
+        all_ok = all(i->_stm_matches(p_args[i], st[i], debug, indent*"  "), 1:dots_start-1) &&
+            all(i->_stm_matches(p_args[end-i], st[end-i], debug, indent*"  "), n_after-1:-1:0)
+        debug && printstyled(indent, st, all_ok ? " matched\n" : " not matched\n";
+                             color=(all_ok ? :green : :red))
+        return all_ok
+    end
+    @assert false
+end
+
+# Assuming _stm_matches, construct an Expr that assigns syms to SyntaxTrees.
+# Note st_rhs_expr is a ref-expr with a SyntaxTree/List value (in context).
+function _stm_assigns(p, st_rhs_expr; assigns=Expr(:block))
+    if p isa Symbol && p != :_
+        push!(assigns.args, Expr(:(=), p, st_rhs_expr))
+    elseif p isa Expr
+        p_args = filter(e->!(e isa LineNumberNode), p.args)[2:end]
+        dots_i = findfirst(x->Meta.isexpr(x, :(...)), p_args)
+        dots_start = something(dots_i, length(p_args) + 1)
+        n_after = length(p_args) - dots_start
+        for i in 1:dots_start-1
+            _stm_assigns(p_args[i], :($st_rhs_expr[$i]); assigns)
+        end
+        if !isnothing(dots_i)
+            _stm_assigns(p_args[dots_i].args[1],
+                         :($st_rhs_expr[$dots_i:end-$n_after]); assigns)
+            for i in n_after-1:-1:0
+                _stm_assigns(p_args[end-i], :($st_rhs_expr[end-$i]); assigns)
+            end
+        end
+    end
+    return assigns
+    @assert false
+end
+
+# Check for correct pattern syntax.  Not needed outside of development.
+function _stm_check_usage(pats)
+    function _stm_check_pattern(p; syms=Set{Symbol}())
+        if Meta.isexpr(p, :(...), 1)
+            p = p.args[1]
+            @assert(p isa Symbol, "Expected symbol before `...` in $p")
+        end
+        if p isa Symbol
+            # No support for duplicate syms for now (user is either looking for
+            # some form of equality we don't implement, or they made a mistake)
+            dup = p in syms && p !== :_
+            push!(syms, p)
+            return !dup || @assert(false, "invalid duplicate non-underscore identifier $p")
+        end
+        return (Meta.isexpr(p, :vect, 1) ||
+            (Meta.isexpr(p, :hcat) &&
+            isnothing(@assert(count(x->Meta.isexpr(x, :(...)), p.args[2:end]) <= 1,
+                              "Multiple `...` in a pattern is ambiguous")) &&
+            all(x->_stm_check_pattern(x; syms), p.args[2:end])) &&
+            # This exact syntax is not necessary since the kind can't be
+            # provided by a variable, but requiring [K"kinds"] is consistent.
+            Meta.isexpr(p.args[1], :macrocall, 3) &&
+            p.args[1].args[1] === Symbol("@K_str") && p.args[1].args[3] isa String)
+    end
+
+    @assert Meta.isexpr(pats, :block) "Usage: @st_match st begin; ...; end"
+    for per in filter(e->!isa(e, LineNumberNode), pats.args)
+        @assert(Meta.isexpr(per, :(->), 2), "Expected pat -> res, got malformed pair: $per")
+        if Meta.isexpr(per.args[1], :tuple)
+            @assert length(per.args[1].args) >= 2 "Unnecessary tuple in $(per.args[1])"
+            for e in per.args[1].args[2:end]
+                @assert(Meta.isexpr(e, :(=), 2) && e.args[1] in (:when, :run, QuoteNode(:run)),
+                        "Expected `when=<cond>` or `run=<stmts>`, got $e")
+            end
+            p = per.args[1].args[1]
+        else
+            p = per.args[1]
+        end
+        @assert _stm_check_pattern(p) "Malformed pattern: $p"
+    end
+end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -1,0 +1,912 @@
+struct ValidationDiagnostic <: Exception
+    sts::SyntaxList
+    msg::String
+end
+ValidationDiagnostic(st::SyntaxTree, msg::String) =
+    ValidationDiagnostic(SyntaxList(syntax_graph(st), NodeId[st._id]), msg)
+
+# This could probably be one or several scoped values instead.
+"""
+Error vector (shared per invocation of valid_st1) and flags.
+
+Flags are mainly to avoid keyword argument spam for parameters that are updated
+rarely, but apply recursively, usually to remember the kinds of structures we're
+in (e.g. vcx.toplevel becomes false in any function).
+
+By default, assume we are validating a usual lowering input (top-level) that has
+been macroexpanded.
+"""
+struct Validation1Context
+    _flags::Base.PersistentDict{Symbol, Any}
+    errors::Vector{ValidationDiagnostic}
+    # warnings::Vector{ValidationDiagnostic}
+end
+Validation1Context() = Validation1Context(
+    Base.PersistentDict{Symbol, Any}(
+        :speculative => false, # match not required; disable errors and return a bool
+        :toplevel => true, # not in any lambda body
+        :in_gscope => true, # not in any scope; implies toplevel
+        :in_loop => false, # break/continue allowed
+        :inner_cond => false, # inner methods not allowed.  true in ? (args 2-3), &&, and ||
+        :return_ok => true, # yes usually (even outside of functions), no in comprehensions/generators
+        # syntax TODO: no return in finally? type declarations?
+
+        # We currently always parse to K"=", but Expr(:kw) is valid here and Expr(:(=)) is not
+        # :assign_ok => true, # no in vect, curly, [typed_]h/v/ncat
+        # :beginend_ok => false # once this is different from the identifier
+
+        # vst0 shares this context type since macro expansion doesn't recurse
+        # into some forms, and most parts of the AST are the same.
+        :unexpanded => false,
+        :quote_level => 0,
+    ), ValidationDiagnostic[])
+
+with(vcx::Validation1Context, p1, pairs...) =
+    Validation1Context(Base.PersistentDict{Symbol, Any}(vcx._flags, p1), vcx.errors)
+with(vcx::Validation1Context, p1, p2, pairs...) = with(with(vcx, p1), p2, pairs...)
+
+function Base.getproperty(vcx::Validation1Context, param::Symbol)
+    param in (:errors, :warnings, :_flags) ?
+        getfield(vcx, param) :
+        get(getfield(vcx, :_flags), param, nothing)
+end
+
+"""
+Executable grammar of the input language to lowering (post-macro-expansion).
+
+This should serve three purposes:
+(1) A readable reference for the julia AST structure.
+(2) A set of assumptions we can use in lowering (a guard against many forms of
+    invalid input).  If `valid_st1(st)` returns true, lowering is expected to
+    produce correct output given `st` (possibly by throwing a LoweringError).
+(3) The place we throw helpful user-facing errors given malformed ASTs.
+
+Only AST structure is checked.  Checking that required attributes exist, that
+leaf-only (or not) kinds are leaves (or not), and that syntax flags are valid
+per kind should be done in a separate pass that doesn't need to consider
+structure.
+"""
+function valid_st1(st::SyntaxTree)
+    vcx = Validation1Context()
+    valid = valid_st1(vcx, st)
+    for (i, e) in enumerate(vcx.errors)
+        printstyled("error $i:\n"; color=:red)
+        showerror(stdout, LoweringError(e.sts[1], e.msg))
+        for st_ in e.sts[2:end]; show(st_); end
+        printstyled("---------------------------------\n"; color=:red)
+    end
+    return valid
+end
+
+function valid_st1(vcx::Validation1Context, st::SyntaxTree)
+    pass = vst1_stmt(vcx, st)
+    !pass && isempty(vcx.errors) &&
+        fail(vcx, st, "invalid syntax: unknown kind `$(kind(st))` or number of arguments ($(numchildren(st)))")
+    return pass
+end
+
+# temp function to keep LoweringErrors the same as before, producing only one
+# error with only one associated tree
+function valid_st1_or_throw(st::SyntaxTree)
+    vcx = Validation1Context()
+    valid = valid_st1(vcx, st)
+    if !isempty(vcx.errors) & !valid
+        e1 = vcx.errors[1]
+        throw(LoweringError(e1.sts[1], e1.msg))
+    elseif isempty(vcx.errors) & valid
+        return nothing
+    else
+        throw(LoweringError(st, "validator bug: returned $valid but with $(length(vcx.errors)) errors"))
+    end
+end
+
+vst1_value(vcx::Validation1Context, st::SyntaxTree; need_value=true) = @stm st begin
+    (leaf, when=kind(leaf) in KSet"""Identifier Value Symbol Integer Float
+        String Char Bool CmdString HexInt OctInt BinInt""") -> true
+
+    # Container nodes that may or may not be values depending on their
+    # contents; callers of vst1_value can specify that they don't need a value.
+    [K"block" _...] -> vst1_block(vcx, st; need_value)
+    [K"let" [K"block" decls...] body] -> allv(vst1_symdecl_or_assign, vcx, decls) &
+        vst1_block(with(vcx, :in_gscope=>false), body; need_value)
+    [K"if" cond t] -> vst1_value(vcx, cond) &
+        vst1_value(vcx.toplevel ? vcx : with(vcx, :inner_cond=>true), t; need_value)
+    [K"if" cond t f] -> vst1_value(vcx, cond) &
+        vst1_value(vcx.toplevel ? vcx : with(vcx, :inner_cond=>true), t; need_value) &
+        vst1_else(vcx.toplevel ? vcx : with(vcx, :inner_cond=>true), f; need_value)
+
+    # op-assign will perform the op, but fail to assign with a bad lhs, so we
+    # disallow it here
+    [K"="    l r] -> vst1_assign_lhs(vcx, l) & vst1_value(vcx, r)
+    [K"op="  l op r] -> vst1_assign_lhs(vcx, l) & vst1_ident(vcx, op) & vst1_value(vcx, r)
+    [K".="   l r] -> vst1_dotassign_lhs(vcx, l) & vst1_value(vcx, r)
+    [K".op=" l op r] -> vst1_dotassign_lhs(vcx, l) & vst1_ident(vcx, op) & vst1_value(vcx, r)
+
+    [K"function" _...] -> !vcx.inner_cond || vcx.toplevel ? vst1_function(vcx, st) :
+        fail(vcx, st, "conditional inner method definitions are not supported; use `()->()` syntax instead")
+    [K"call" _...] -> vst1_call(vcx, st)
+    [K"dotcall" _...] -> vst1_dotcall(vcx, st)
+    [K"return"] -> vcx.return_ok || fail(vcx, st, "`return` not allowed inside comprehension or generator")
+    [K"return" val] -> vcx.return_ok ? vst1_value(vcx, val) :
+        fail(vcx, st, "`return` not allowed inside comprehension or generator")
+    [K"continue"] -> vcx.in_loop || fail(vcx, st, "`continue` must be used inside a `while` or `for` loop")
+    [K"break"] -> vcx.in_loop || fail(vcx, st, "`break` must be used inside a `while` or `for` loop")
+    [K"?" cond t f] -> vst1_value(vcx, cond) &
+        vst1_value(vcx.toplevel ? vcx : with(vcx, :inner_cond=>true), t) &
+        vst1_value(vcx.toplevel ? vcx : with(vcx, :inner_cond=>true), f)
+    [K"for" [K"iteration" is...] [K"block" body...]] ->
+        allv(vst1_iter, vcx, is) &
+        allv(vst1_stmt, with(vcx, :in_loop=>true, :in_gscope=>false), body)
+    [K"while" cond [K"block" body...]] ->
+        vst1_value(vcx, cond) &
+        allv(vst1_stmt, with(vcx, :in_loop=>true, :in_gscope=>false), body)
+    [K"try" _...] -> vst1_try(vcx, st)
+    [K"macrocall" _...] -> vcx.unexpanded ? vst0_macrocall(vcx, st) :
+        fail(vcx, st, "macrocall not valid in AST after macro expansion")
+    [K"quote" x] -> vcx.unexpanded ? vst0_quoted(with(vcx, :quote_level=>1), x) :
+        fail(vcx, st, "interpolating quote not valid in AST after macro expansion")
+    [K"$" x] -> fail(vcx, st, raw"`$` expression outside string or quote")
+    [K"tuple" xs... [K"parameters" kws...]] ->
+        allv(vst1_splat_or_val, vcx, xs) & allv(vst1_call_arg, vcx, kws)
+    [K"tuple" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    [K"." x y] -> vst1_value(vcx, x) & vst1_dot_rhs(vcx, y)
+    [K"." x] -> vst1_value(vcx, x)
+    [K":"] -> true # ast TODO: this doesn't need to be a kind.  note a:b is a call, this is a[:] or just :
+    [K"curly" t xs...] -> vst1_value(vcx, t) & allv(vst1_value_curly_typevar, vcx, xs)
+    [K"where" lhs rhs] -> vst1_value(vcx, lhs) & vst1_where_rhs(vcx, rhs)
+    [K"string" xs...] -> allv(vst1_value, vcx, xs)
+    [K"->" _...] -> vst1_lam(vcx, st)
+    [K"generator" _...] -> vst1_generator(vcx, st)
+    [K"comprehension" g] -> vst1_generator(vcx, g)
+    [K"typed_comprehension" t g] -> vst1_value(with(vcx, :return_ok=>false), t) & vst1_generator(vcx, g)
+    [K"comparison" xs...] -> length(xs) < 3 || iseven(length(xs)) ?
+        fail(vcx, st, "`comparison` expects n>=3 args and odd n") :
+        # TODO: xs[2:2:end] should just be identifier or (. identifier)
+        allv(vst1_value, vcx, xs[2:2:end]) & allv(vst1_value, vcx, xs[1:2:end])
+    # docstring-annotated call should have calldecl structure
+    ([K"doc" [K"string" strs...] callex],
+     when=vst1_function_calldecl(with(vcx, :speculative=>true), st[2])) ->
+         allv(vst1_value, vcx, strs)
+    [K"doc" [K"string" strs...] x] ->
+        allv(vst1_value, vcx, strs) & vst1_stmt(vcx, x)
+    [K"<:" x y] -> vst1_value(vcx, x) & vst1_value(vcx, y)
+    [K">:" x y] -> vst1_value(vcx, x) & vst1_value(vcx, y)
+    [K"-->" x y] -> vst1_value(vcx, x) & vst1_value(vcx, y)
+    [K"::" x y] -> vst1_value(vcx, x) & vst1_value(vcx, y)
+    [K"&&" xs...] -> allv(vst1_value, vcx, xs)
+    [K"||" xs...] -> allv(vst1_value, vcx, xs)
+    [K".&&" x y] -> vst1_value(vcx, x) & vst1_value(vcx, y)
+    [K".||" x y] -> vst1_value(vcx, x) & vst1_value(vcx, y)
+    (_, run=pass_or_err(vst1_arraylike, vcx, st), when=run.known) -> run.pass
+    # value-producing const, global-=
+    [K"const" [K"global" x]] -> vst1_const_assign(vcx, x)
+    [K"global" [K"const" x]] -> vst1_const_assign(vcx, x)
+    [K"const" x] -> !vcx.in_gscope ?
+        fail(vcx, st, "unsupported `const` declaration on local variable") :
+        vst1_const_assign(vcx, x)
+    [K"global" [K"=" l r]] ->
+        vst1_assign_lhs(vcx, l; disallow_type=!vcx.toplevel) &
+        vst1_value(vcx, r)
+    # TODO: local is always OK as a value, but non-assigning should probably not be
+    [K"local" xs...] -> allv(vst1_symdecl_or_assign, vcx, xs)
+
+    # Forms not produced by the parser
+    [K"inert" _] -> true
+    [K"core"] -> true
+    [K"top"] -> true
+    [K"meta" _...] -> true # TODO documented forms, once we figure out how we'll deal with this
+    [K"extension" [K"Symbol"] _...] ->
+        (st[1].name_val in ("locals", "islocal", "isglobal") || fail(vcx, st, "unknown extension kind"))
+    [K"toplevel" xs...] -> # contents will be unexpanded
+        allv(valid_st0, with(vcx, :toplevel=>true, :in_gscope=>true), xs)
+    [K"opaque_closure" argt lb ub [K"Bool"] lam] ->
+        allv(vst1_value, vcx, [argt, lb, ub]) & vst1_lam(vcx, lam)
+    [K"gc_preserve" x ids...] -> vst1_value(vcx, x) & allv(vst1_ident, vcx, ids)
+    [K"gc_preserve_begin" ids...] -> allv(vst1_ident, vcx, ids)
+    [K"gc_preserve_end" ids...] -> allv(vst1_ident, vcx, ids)
+    # [K"thisfunction"] -> !vcx.toplevel && vcx.return_ok ||
+    #     fail(vcx, st, "`thisfunction` is not defined in generators or outside of functions")
+    [K"isdefined" [K"Identifier"]] -> true
+    [K"lambda" [K"block" b1...] [K"block" b2...] [K"->" _...]] ->
+        allv(vst1_ident, vcx, b1) &
+        allv(vst1_ident, vcx, b2) &
+        vst1_lam(vcx, st[3])
+    [K"generated"] -> true
+    ([K"foreigncall" f [K"static_eval" rt] [K"static_eval" argt_svec] args...],
+     when=kind(f) in (K"Symbol", K"Identifier")) ->
+        vst1_value(vcx, rt) & vst1_value(vcx, argt_svec) & allv(vst1_value, vcx, args)
+    [K"cfunction" t [K"static_eval" fptr] [K"static_eval" rt] [K"static_eval" argt_svec] [K"Symbol"]] ->
+        vst1_value(vcx, t) & vst1_value(vcx, fptr) & vst1_value(vcx, rt) & vst1_value(vcx, argt_svec)
+    [K"cfunction" t fptr [K"static_eval" rt] [K"static_eval" argt_svec] [K"Symbol"]] ->
+        vst1_value(vcx, t) & vst1_value(vcx, fptr) & vst1_value(vcx, rt) & vst1_value(vcx, argt_svec)
+    [K"scope_block" x] -> vst1_value(vcx, x; need_value)
+
+    # forms normalized by expand_forms_1, so not valid in st1.  TODO: we should
+    # consider doing each of these normalizations before macro expansion rather
+    # than after.
+    ([K"juxtapose" xs...], when=vcx.unexpanded) -> allv(vst1_value, vcx, xs)
+    ([K"cmdstring" x], when=vcx.unexpanded) -> vst1_value(vcx, x)
+    ([K"char" [K"Char"]], when=vcx.unexpanded) -> true
+    ([K"var" [K"Identifier"]], when=vcx.unexpanded) -> true
+
+    # Invalid forms for which we want to produce detailed errors.
+    # TODO: the number of these cases is unbounded (e.g. bad kind or number of
+    # arguments to any of the kinds above); move them to a separate function to
+    # stop cluttering the grammar?
+    [K"..." _...] -> fail(vcx, st, "unexpected splat not in `call`, `tuple`, `curly`, or array expression")
+    [K"parameters" _...] -> fail(vcx, st, "unexpected keyword-separating semicolon outside of call or tuple")
+    [K"braces" _...] -> fail(vcx, st, "`braces` outside of `where` is reserved for future use")
+    [K"bracescat" _...] -> fail(vcx, st, "`bracescat` is reserved for future use")
+    [K"do" _...] -> fail(vcx, st, "unexpected `do` outside of `call`")
+    [K"Placeholder"] -> fail(vcx, st, "all-underscore identifiers are write-only and their values cannot be used in expressions")
+    [K"atomic" _...] -> fail(vcx, st, "unimplemented or unsupported `atomic` declaration")
+    (_, when=need_value && kind(st) in KSet"symbolic_label symbolic_goto") ->
+        fail(vcx, st, "misplaced `$(kind(st))` in value position")
+    ([K"global" _...], when=need_value) ->
+        fail(vcx, st, "global declaration doesn't read the variable and can't return a value")
+
+    (_, run=pass_or_err(vst1_toplevel_only_value, vcx, st), when=run.known) ->
+        run.pass && (vcx.toplevel || fail(vcx, st, "this syntax is only allowed in top level code"))
+    _ -> false
+end
+
+vst1_toplevel_only_value(vcx::Validation1Context, st::SyntaxTree) = @stm st begin
+    [K"module" name [K"block" xs...]] -> (
+        vst1_ident(vcx, name) & allv(valid_st0, with(vcx, :toplevel=>true, :in_gscope=>true), xs))
+    [K"macro" _...] -> vst1_macro(vcx, st)
+    # The following return nothing, but are allowed as values
+    [K"struct" sig [K"block" body...]] -> vst1_typesig(vcx, sig) &
+        allv(vst1_struct_field, vcx, body)
+    [K"abstract" sig] -> vst1_typesig(vcx, sig)
+    [K"primitive" sig [K"Integer"]] -> vst1_typesig(vcx, sig)
+    [K"primitive" sig n] -> vst1_typesig(vcx, sig) & vst1_value(vcx, n) # allowed?
+    _ -> false
+end
+
+vst1_stmt(vcx::Validation1Context, st::SyntaxTree) = @stm st begin
+    (_, run=pass_or_err(vst1_value, vcx, st; need_value=false), when=run.known) -> run.pass
+    ([K"global" xs...], when=vcx.toplevel) -> allv(vst1_symdecl_or_assign, vcx, xs)
+    ([K"global" xs...], when=!vcx.toplevel) -> allv(vst1_inner_global_decl, vcx, xs)
+    [K"local" xs...] -> allv(vst1_symdecl_or_assign, vcx, xs) # TODO: fail if immediate toplevel
+    [K"symbolic_label"] -> true
+    [K"symbolic_goto"] -> true
+
+    (_, run=pass_or_err(vst1_toplevel_only_stmt, vcx, st), when=run.known) ->
+        run.pass && (vcx.toplevel || fail(vcx, st, "this syntax is only allowed in top level code"))
+    _ -> fail(vcx, st, "invalid syntax: unknown kind `$(kind(st))` or number of arguments ($(numchildren(st)))")
+end
+
+vst1_inner_global_decl(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"=" l r] -> vst1_assign_lhs(vcx, l; disallow_type=true) & vst1_value(vcx, r)
+    [K"function" _...] -> vst1_function(vcx, st) &&
+        JuliaSyntax.has_flags(st, JuliaSyntax.SHORT_FORM_FUNCTION_FLAG)
+
+    [K"::" _...] -> fail(vcx, st, "type declarations for global variables must be at top level, not inside a function")
+    _ -> fail(vcx, st, "invalid global declaration: expected identifier or assignment")
+end
+
+vst1_toplevel_only_stmt(vcx::Validation1Context, st::SyntaxTree) = @stm st begin
+    # Parsing is stricter (no "as" in no-colon using)
+    [K"import" [K":" p1 ps...]] ->
+        (vst1_importpath(vcx, p1; dots_ok=true) &
+        allv(vst1_importpath, vcx, ps; dots_ok=false))
+    [K"using"  [K":" p1 ps...]] ->
+        (vst1_importpath(vcx, p1; dots_ok=true) &
+        allv(vst1_importpath, vcx, ps; dots_ok=false))
+    [K"import" ps...] -> allv(vst1_importpath, vcx, ps; dots_ok=true)
+    [K"using"  ps...] -> allv(vst1_importpath, vcx, ps; dots_ok=true)
+    [K"public" xs...] -> allv(vst1_ident, vcx, xs)
+    [K"export" xs...] -> allv(vst1_ident, vcx, xs)
+    [K"latestworld"] -> true
+    [K"latestworld_if_toplevel"] -> true
+    _ -> false
+end
+
+# @stm doesn't work so well with n dots and m identifiers
+# one of:
+# (as (importpath . . . x y z) ident)
+#     (importpath . . . x y z)
+# where y, z may be quoted for no reason (do we need to allow this?)
+function vst1_importpath(vcx, st; dots_ok)
+    ok = true
+    path_components = @stm st begin
+        [K"as" [K"importpath" xs...] as2] -> (
+            if !vst1_ident(vcx, as2)
+                fail(vcx, as2, "expected identifier after `as`")
+                ok = false
+            end; xs)
+        [K"importpath" xs...] -> xs
+    end
+    seen_first = false
+    for c in path_components
+        if kind(c) === K"."
+            if !dots_ok || seen_first
+                ok = false
+                fail(vcx, c, "unexpected `.` in import path")
+            end
+            continue
+        end
+        ok = ok && vst1_ident(vcx, seen_first && kind(c) === K"quote" ? c[1] : c)
+        seen_first = true
+    end
+    !seen_first && fail(vcx, st, "expected identifier in `importpath`")
+    return ok && seen_first
+end
+
+vst1_block(vcx, st; need_value=true) = @stm st begin
+    [K"block"] -> true
+    ([K"block" xs...], when=!need_value) -> allv(vst1_stmt, vcx, xs)
+    [K"block" xs... val] -> allv(vst1_stmt, vcx, xs) & vst1_value(vcx, val)
+    _ -> fail(vcx, st, "expected `block`")
+end
+
+vst1_else(vcx, st; need_value) = @stm st begin
+    [K"block" _...] -> vst1_block(vcx, st; need_value)
+    [K"elseif" cond t f] ->
+        vst1_value(vcx, cond) & vst1_block(vcx, t; need_value) & vst1_else(vcx, f; need_value)
+    _ -> vst1_value(vcx, st; need_value)
+end
+
+# TODO: catch and else are in value position
+vst1_try(vcx, st) = @stm st begin
+    [K"try" _] -> fail(vcx, st, "try without catch or finally")
+    [K"try" b1 [K"catch" err body2...]] ->
+        vst1_block(vcx, b1) &
+        vst1_ident_lhs(vcx, err) &
+        allv(vst1_stmt, vcx, body2)
+    [K"try" b1 [K"else" body3...]] ->
+        fail(vcx, st, "try without catch or finally")
+    [K"try" b1 [K"finally" body4...]] ->
+        vst1_block(vcx, b1) &
+        allv(vst1_stmt, vcx, body4)
+    [K"try" b1 [K"catch" err body2...] [K"else" body3...]] ->
+        vst1_block(vcx, b1) &
+        vst1_ident_lhs(vcx, err) &
+        allv(vst1_stmt, vcx, body2) &
+        allv(vst1_stmt, vcx, body3)
+    [K"try" b1 [K"catch" err body2...] [K"finally" body4...]] ->
+        vst1_block(vcx, b1) &
+        vst1_ident_lhs(vcx, err) &
+        allv(vst1_stmt, vcx, body2) &
+        allv(vst1_stmt, vcx, body4)
+    [K"try" b1 [K"else" body3...] [K"finally" body4...]] ->
+        vst1_block(vcx, b1) &
+        allv(vst1_stmt, vcx, body4)
+    [K"try" b1 [K"catch" err body2...] [K"else" body3...] [K"finally" body4...]] ->
+        vst1_block(vcx, b1) &
+        vst1_ident_lhs(vcx, err) &
+        allv(vst1_stmt, vcx, body2) &
+        allv(vst1_stmt, vcx, body3) &
+        allv(vst1_stmt, vcx, body4)
+    _ -> fail(vcx, st, "malformed `try` expression")
+end
+
+# syntax TODO:
+# - const is inoperative in the function case
+# - single-arg const with no value (presumably to poison this name) was likely
+#   not intended to work, and can only be produced by macros
+vst1_const_assign(vcx, st) = @stm st begin
+    (_, when=!vcx.toplevel) -> fail(vcx, st, "`const` declaration not allowed inside function")
+    [K"=" l r] -> vst1_assign_lhs(vcx, l; in_const=true) & vst1_value(vcx, r)
+    [K"function" _...] -> vst1_function(vcx, st) &&
+        JuliaSyntax.has_flags(st, JuliaSyntax.SHORT_FORM_FUNCTION_FLAG)
+    [K"Identifier"] -> true
+
+    [K"local" _...] -> fail(vcx, st, "locals cannot be declarated `const`")
+    _ -> fail(vcx, st, "expected assignment after `const`")
+end
+
+# We can't validate A.B in general (usually lowers to getproperty), but it shows
+# up in a number of syntax special cases where we can.
+vst1_dotpath(vcx, st) = @stm st begin
+    [K"." l r] -> vst1_dotpath(vcx, l) & vst1_dot_rhs(vcx, r)
+    [K"Value"] -> typeof(st.value) in (Module, GlobalRef)
+    lhs -> vst1_ident(vcx, lhs)
+end
+
+vst1_dot_rhs(vcx, st) = (vcx.unexpanded ?
+    kind(st) === K"Identifier" : kind(st) === K"Symbol") ||
+    kind(st) === K"string" || # syntax TODO: disallow
+    fail(vcx, st, "`(. a b)` requires symbol `b` after macro-expansion, or identifier before")
+
+cst1_assign(vcx, st) = @stm st begin
+    [K"=" l r] -> vst1_assign_lhs(vcx, l) & vst1_value(vcx, r)
+    [K"function" _...] -> vst1_function(vcx, st) &&
+        JuliaSyntax.has_flags(st, JuliaSyntax.SHORT_FORM_FUNCTION_FLAG)
+    _ -> false
+end
+
+vst1_symdecl_or_assign(vcx, st) = cst1_assign(vcx, st) || vst1_symdecl(vcx, st)
+
+vst1_symdecl(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"::" [K"Identifier"] t] -> vst1_value(vcx, t)
+    _ -> fail(vcx, st, "expected identifier or `::`")
+end
+
+# ast TODO: Omit the `var` container at the parser level.  This would let us
+# delete these entirely and just match [K"Identifier"] instead.
+# TODO: A K"Value" globalref is often OK in place of an identifier; check usage
+# of this function
+vst1_ident(vcx, st) =
+    cst1_ident(vcx, st) || fail(vcx, st, "expected identifier, got `$(kind(st))`")
+cst1_ident(vcx, st) = @stm st begin
+    [K"Identifier"] -> true
+    [K"var" [K"Identifier"]] -> vcx.unexpanded ? true :
+        fail(vcx, st, "`var` container not valid after macro expansion")
+    _ -> false
+end
+
+vst1_ident_lhs(vcx, st) = @stm st begin
+    [K"Placeholder"] -> true
+    _ -> vst1_ident(vcx, st)
+end
+
+# no kws in macrocalls, but `do` is OK.
+# TODO: we move `do` between st0 and st1...
+vst1_call(vcx, st) = @stm st begin
+    ([K"call" a0 op a1], when=(vcx.unexpanded && is_infix_op_call(st))) ->
+        vst1_value(vcx, a0) &
+        vst1_ident(vcx, op) &
+        vst1_value(vcx, a1)
+    ([K"call" a0 op], when=(vcx.unexpanded && is_postfix_op_call(st))) ->
+        vst1_value(vcx, a0) &
+        vst1_ident(vcx, op)
+    [K"call" f [K"do" _...] args... [K"parameters" kwargs...]] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args) &
+        allv(vst1_call_kwarg, vcx, kwargs) &
+        vst1_do(vcx, st[2])
+    [K"call" f args... [K"parameters" kwargs...]] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args) &
+        allv(vst1_call_kwarg, vcx, kwargs)
+    [K"call" f [K"do" _...] args...] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args) &
+        vst1_do(vcx, st[2])
+    [K"call" f args...] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args)
+    _ -> fail(vcx, st, "invalid `call` form")
+end
+
+# unfortunate duplicate of the above
+vst1_dotcall(vcx, st) = @stm st begin
+    ([K"dotcall" a0 op a1], when=(vcx.unexpanded && is_infix_op_call(st))) ->
+        vst1_value(vcx, a0) &
+        vst1_ident(vcx, op) &
+        vst1_value(vcx, a1)
+    ([K"dotcall" a0 op], when=(vcx.unexpanded && is_postfix_op_call(st))) ->
+        vst1_value(vcx, a0) &
+        vst1_ident(vcx, op)
+    [K"dotcall" f [K"do" _...] args... [K"parameters" kwargs...]] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args) &
+        allv(vst1_call_kwarg, vcx, kwargs) &
+        vst1_do(vcx, st[2])
+    [K"dotcall" f args... [K"parameters" kwargs...]] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args) &
+        allv(vst1_call_kwarg, vcx, kwargs)
+    [K"dotcall" f [K"do" _...] args...] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args) &
+        vst1_do(vcx, st[2])
+    [K"dotcall" f args...] ->
+        vst1_value(vcx, f) &
+        allv(vst1_call_arg, vcx, args)
+    _ -> fail(vcx, st, "invalid `call` form")
+end
+
+# Arg to call (not function decl), pre-semicolon.  This can be anything, but
+# assignments (interpreted as kwargs) must have a simple LHS, and splat is OK.
+vst1_call_arg(vcx, st) = @stm st begin
+    [K"=" id val] -> vst1_ident(vcx, id) & vst1_value(vcx, val)
+    [K"..." x] -> vst1_value(vcx, x) # complex assignment in here is OK
+    _ -> vst1_value(vcx, st)
+end
+
+# Arg to `parameters` (post-semicolon) in a call (not function decl) can be:
+# - ident
+# - ident=value
+# - :ident=>value
+# - value...
+vst1_call_kwarg(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"=" id val] -> vst1_ident(vcx, id) & vst1_value(vcx, val)
+    # TODO: this call isn't necessarily infix, and we should check name_val is =>
+    [K"call" [K"quote" id] arrow v] -> vst1_ident(vcx, id) &
+        vst1_ident(vcx, arrow) & vst1_value(v)
+    [K"..." x] -> vst1_value(vcx, x)
+    _ -> fail(vcx, st, "malformed `parameters`; expected identifier, `=`, or, `...`")
+end
+
+vst1_lam(vcx, st) = @stm st begin
+    [K"->" l r] ->
+        vst1_lam_lhs(with(vcx, :return_ok=>false, :toplevel=>false, :in_gscope=>false), l) &
+        vst1_stmt(with(vcx, :return_ok=>true, :toplevel=>false, :in_gscope=>false), r)
+    _ -> false
+end
+
+vst1_lam_lhs(vcx, st) = @stm st begin
+    [K"tuple" ps... [K"parameters" _...]] ->
+        _calldecl_positionals(vcx, ps) & vst1_calldecl_kws(vcx, st[end])
+    [K"tuple" ps...] -> _calldecl_positionals(vcx, ps)
+    [K"where" ps t] -> vst1_lam_lhs(vcx, ps) & vst1_where_rhs(vcx, t)
+    # ast TODO: This is handled badly in the parser
+    [K"block" ps...] -> allv(vst1_param_kw, vcx, ps)
+    _ -> fail(vcx, st, "malformed `->` expression")
+end
+
+vst1_do(vcx, st) = @stm st begin
+    [K"do" [K"tuple" ps...] b] ->
+        allv(vst1_param_req, with(vcx, :return_ok=>false, :toplevel=>false, :in_gscope=>false), ps) &
+        vst1_block(with(vcx, :return_ok=>true, :toplevel=>false, :in_gscope=>false), b)
+    _ -> fail(vcx, st, "malformed `do` expression")
+end
+
+vst1_function(vcx, st) = @stm st begin
+    [K"function" name] -> vst1_ident(vcx, name)
+    [K"function" callex body] ->
+        vst1_function_calldecl(with(vcx, :return_ok=>false, :toplevel=>false, :in_gscope=>false), callex) &
+        # usually a block, but not in the function-= case
+        # TODO: should body be a value?
+        vst1_stmt(with(vcx, :return_ok=>true, :toplevel=>false, :in_gscope=>false), body)
+    _ -> fail(vcx, st, "malformed `function`")
+end
+
+# Note that we consistently refer to children of a declaring call as
+# "parameters" rather than arguments (and children of a K"parameters" block as
+# "keyword args/params") so we don't mix them up with children to a real call,
+# whose valid forms are subtly different.
+
+vst1_function_calldecl(vcx, st) = @stm st begin
+    [K"where" callex tvs] ->
+        vst1_function_calldecl(vcx, callex) & vst1_where_rhs(vcx, tvs)
+    [K"::" callex rt] ->
+        vst1_simple_calldecl(vcx, callex) & vst1_value(vcx, rt)
+    _ -> vst1_simple_calldecl(vcx, st)
+end
+
+vst1_simple_calldecl(vcx, st; in_macro=false) = @stm st begin
+    [K"call" f ps... [K"parameters" _...]] -> vst1_calldecl_name(vcx, f) &
+        _calldecl_positionals(vcx, ps) &
+        vst1_calldecl_kws(vcx, st[end])
+    [K"call" f ps...] -> vst1_calldecl_name(vcx, f) &
+        _calldecl_positionals(vcx, ps)
+
+    # anonymous function syntax `function (x)` ?!
+    [K"tuple" ps... [K"parameters" _...]] -> _calldecl_positionals(vcx, ps) &
+        vst1_calldecl_kws(vcx, st[end])
+    [K"tuple" ps...] -> _calldecl_positionals(vcx, ps)
+
+    [K"dotcall" _...] -> fail(vcx, st, "cannot define function using `.` broadcast syntax")
+    _ -> fail(vcx, st, "malformed `call` in function decl")
+end
+
+vst1_macro(vcx, st) = @stm st begin
+    (_, when=!vcx.in_gscope) -> fail(vcx, st, "macro definition is not allowed in a local scope")
+    [K"macro" m] -> vst1_ident(vcx, m)
+    [K"macro" [K"call" _... [K"parameters" _...]] _...] ->
+        fail(vcx, st[1][end], "macros cannot accept keyword arguments")
+    [K"macro" [K"call" m ps...] body] ->
+        let vcx = with(vcx, :return_ok=>false, :toplevel=>false, :in_gscope=>false)
+            vst1_macro_calldecl_name(vcx, m) &
+                _calldecl_positionals(vcx, ps) &
+                vst1_block(with(vcx, :return_ok=>true), body)
+        end
+end
+
+vst1_macro_calldecl_name(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"." l r] -> vst1_dotpath(vcx, l) & vst1_dot_rhs(vcx, r)
+    _ -> fail(vcx, st, "invalid macro name")
+end
+
+vst1_calldecl_name(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"." l r] -> vst1_dotpath(vcx, l) & vst1_dot_rhs(vcx, r)
+    [K"curly" t tvs...] -> vst1_calldecl_name(vcx, t) & allv(vst1_value, vcx, tvs)
+    [K"Value"] -> true # GlobalRef works. Function? Type?
+    # callable type
+    [K"::" t] -> vst1_value(vcx, t)
+    [K"::" x t] -> vst1_ident(vcx, x) & vst1_value(vcx, t)
+    _ -> fail(vcx, st, "invalid function name")
+end
+
+# Check mandatory and optional positional params. Another case of @stm being too
+# limited: `[required_param* opt_param* (= (... required_param) val)|(... required_param)?]`
+function _calldecl_positionals(vcx, params)
+    require_assign = false
+    ok = true
+    if !isempty(params)
+        maybe_va = params[end]
+        # (= (... required_param) val)
+        if kind(maybe_va) === K"=" && numchildren(maybe_va) === 2
+            ok &= vst1_splat_or_val(vcx, maybe_va[2])
+            maybe_va = maybe_va[1]
+        end
+        # (... required_param)
+        if kind(maybe_va) === K"..."
+            numchildren(maybe_va) !== 1 && fail(vcx, maybe_va, "invalid `...` form")
+            # TODO: can this actually be a tuple?
+            ok &= vst1_param_req_or_tuple(vcx, maybe_va[1])
+            params = params[1:end-1]
+        end
+    end
+    for p in params
+        if kind(p) === K"="
+            require_assign = true
+            ok &= vst1_param_opt(vcx, p)
+        elseif kind(p) === K"..."
+            ok = fail(vcx, p, "`...` may only be used on the final parameter")
+        elseif require_assign # TODO: multi-syntaxtree error
+            ok = fail(vcx, p, "all function parameters after an optional parameter must also be optional")
+        else
+            ok &= vst1_param_req_or_tuple(vcx, p)
+        end
+    end
+    return ok
+end
+
+# destructuring args: function f(a, (x, y)) ...
+vst1_param_req_or_tuple(vcx, st) = @stm st begin
+    [K"::" [K"tuple" _...] t] ->
+        vst1_simple_tuple_lhs(vcx, st[1]) & vst1_value(vcx, t)
+    [K"tuple" _...] -> vst1_simple_tuple_lhs(vcx, st)
+    _ -> vst1_param_req(vcx, st)
+end
+
+vst1_simple_tuple_lhs(vcx, st) = @stm st begin
+    [K"tuple" xs...] -> allv(vst1_simple_tuple_lhs, vcx, xs)
+    _ -> vst1_ident_lhs(vcx, st)
+end
+
+vst1_param_req(vcx, st) = @stm st begin
+    (_, when=vst1_ident_lhs(with(vcx, :speculative=>true), st)) -> true
+    [K"::" x t] -> vst1_ident_lhs(vcx, x) & vst1_value(vcx, t)
+    [K"::" t] -> vst1_value(vcx, t)
+    _ -> fail(vcx, st, "malformed positional param; expected identifier or `::`")
+end
+
+vst1_param_opt(vcx, st) = @stm st begin
+    [K"=" id val] -> vst1_param_req_or_tuple(vcx, id) & vst1_value(vcx, val)
+    _ -> fail(vcx, st, "malformed optional positional param; expected `=`")
+end
+
+vst1_calldecl_kws(vcx, st) = @stm st begin
+    [K"parameters" kws... [K"..." varkw]] ->
+        allv(vst1_param_kw, vcx, kws) & vst1_param_req(vcx, varkw)
+    [K"parameters" kws...] -> allv(vst1_param_kw, vcx, kws)
+end
+
+vst1_param_kw(vcx, st) = @stm st begin
+    (_, when=vst1_symdecl(with(vcx, :speculative=>true), st)) -> true
+    [K"=" id val] -> vst1_symdecl(vcx, id) & vst1_value(vcx, val)
+    [K"..." _...] -> fail(vcx, st, "`...` may only be used for the last keyword parameter")
+    _ -> fail(vcx, st, "malformed keyword parameter; expected identifier, `=`, or `::`")
+end
+
+vst1_where_rhs(vcx, st) = @stm st begin
+    [K"braces" tvs...] -> allv(vst1_typevar_decl, vcx, tvs)
+    _ -> vst1_typevar_decl(vcx, st)
+end
+
+vst1_typevar_decl(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"<:" [K"Identifier"] old] -> vst1_value(vcx, old)
+    [K">:" [K"Identifier"] old] -> vst1_value(vcx, old)
+    ([K"comparison" old1 [K"Identifier"] [K"Identifier"] [K"Identifier"] old2],
+     when=st[2].name_val===st[4].name_val && st[2].name_val in ("<:", ">:")) ->
+         vst1_value(vcx, old1) & vst1_value(vcx, old2)
+
+    [K"<:" x _] -> fail(vcx, x, "expected type name")
+    [K">:" x _] -> fail(vcx, x, "expected type name")
+    [K"comparison" _...] -> fail(vcx, st, "expected `lb <: type_name <: ub` or `ub >: type_name >: lb`")
+    _ -> fail(vcx, st, "expected type name or type bounds")
+end
+
+vst1_typesig(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"<:" [K"curly" name tvs...] super] ->
+        vst1_ident(vcx, name) &
+        vst1_value(vcx, super) &
+        allv(vst1_typevar_decl, vcx, tvs)
+    [K"curly" name tvs...] -> vst1_ident(vcx, name) & allv(vst1_typevar_decl, vcx, tvs)
+    [K"<:" name super] -> vst1_ident(vcx, name) & vst1_value(vcx, super)
+    _ -> fail(vcx, st, "invalid type signature")
+end
+
+# normal, non-lhs curly may have implicit `(<: t)`
+vst1_value_curly_typevar(vcx, st) = @stm st begin
+    [K"<:" t] -> vst1_splat_or_val(vcx, t)
+    [K">:" t] -> vst1_splat_or_val(vcx, t)
+    _ -> vst1_splat_or_val(vcx, st)
+end
+
+vst1_struct_field(vcx, st) = @stm st begin
+    (_, when=cst1_ident(vcx, st)) -> true
+    [K"block" x] -> vst1_struct_field(vcx, x)
+    [K"::" x t] -> vst1_struct_field(vcx, x) & vst1_value(vcx, t)
+    [K"const" x] -> vst1_struct_field(vcx, x)
+    [K"atomic" x] -> vst1_struct_field(vcx, x)
+    _ -> vst1_stmt(vcx, st)
+end
+
+# syntax TODO: (local/global (= lhs rhs)) forms should probably reject the same lhss as const (ref and .)
+# TODO: We can do some destructuring checks here (e.g. fail `(a,b,c) = (1,2)`)
+# compat:
+# - call (only within a tuple using JuliaSyntax) can declare a function with
+#   arguments, but can't use them on the rhs
+# - in curly, typevars are checked for structure, but not used.
+vst1_assign_lhs(vcx, st; in_const=false, in_tuple=false, disallow_type=false) = @stm st begin
+    [K"tuple" [K"parameters" xs...]] -> allv(vst1_symdecl, vcx, xs)
+    [K"tuple" xs...] ->
+        allv(vst1_assign_lhs, vcx, xs; in_const, in_tuple=true) &
+        (count(kind(x)===K"..." for x in xs) <= 1 ||
+        fail(vcx, st, "multiple `...` in destructuring assignment are ambiguous"))
+    # Parser produces this in too many places
+    # [K"call" _...] ->
+    #     fail(vcx, st, "`(= (call ...) ...)` syntax is deprecated, use `(function (call ...) ...)`")
+    # type-annotated tuple segfaults, haha
+    # [K"::" [K"tuple" _...] t] -> ???
+    _ -> vst1_assign_lhs_nontuple(vcx, st; in_const, in_tuple)
+end
+vst1_assign_lhs_nontuple(vcx, st; in_const=false, in_tuple=false, disallow_type=false) = @stm st begin
+    (_, when=vst1_ident_lhs(with(vcx, :speculative=>true), st)) -> true
+    (_, when=(in_const && kind(st) in (K".", K"ref"))) ->
+        fail(vcx, st, "cannot declare this form constant")
+    ([K"Value"], when=st.value isa GlobalRef) -> true
+    ([K"::" x t], when=!disallow_type) ->
+        vst1_assign_lhs(vcx, x; in_const, in_tuple) & vst1_value(vcx, t)
+    [K"call" _...] -> vst1_function_calldecl(vcx, st)
+    [K"." x y] -> vst1_value(vcx, x) & vst1_dot_rhs(vcx, y)
+    [K"..." x] -> !in_tuple ?
+        fail(vcx, st, "splat on left side of assignment must be in a tuple") :
+        vst1_assign_lhs(vcx, x; in_const, in_tuple)
+    [K"ref" x is...] -> vst1_assign_lhs_nontuple(vcx, x; in_const, in_tuple) &
+        allv(vst1_splat_or_val, vcx, is)
+    [K"curly" t tvs...] -> vst1_ident_lhs(vcx, t) &
+        allv(vst1_typevar_decl, vcx, tvs)
+
+    # errors
+    ([K"::" _...], when=disallow_type) ->
+        fail(vcx, st, "type declarations for global variables must be at top level, not inside a function")
+    [K"typed_hcat" _...] -> fail(vcx, st, "invalid spacing on left side of indexed assignment")
+    [K"typed_vcat" _...] -> fail(vcx, st, "unexpected `;` in left side of indexed assignment")
+    [K"typed_ncat" _...] -> fail(vcx, st, "unexpected `;` in left side of indexed assignment")
+    ([K"parameters" _...], when=in_tuple) ->
+        fail(vcx, st, "property destructuring must use a single `;` before the property names, eg `(; a, b) = rhs`")
+    (_, when=(kind(st) in KSet"vect hcat vcat ncat")) -> fail(vcx, st, "use `(a, b) = ...` to assign multiple values")
+    _ -> fail(vcx, st, "invalid `$(kind(st))` on left side of assignment")
+end
+
+# dot-assign with placeholders in an arraylike lhs throws a syntax error
+vst1_dotassign_lhs(vcx, st) =
+    vst1_arraylike(with(vcx, :speculative=>true), st) || vst1_assign_lhs(vcx, st)
+
+vst1_arraylike(vcx, st) = @stm st begin
+    # TODO: more validation is possible here, e.g. when row/nrow can/can't show up in ncat
+    [K"vect" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    [K"hcat" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    [K"vcat" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    [K"ncat" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    [K"ref" x is...] ->        vst1_value(vcx, x) & allv(vst1_splat_or_val, vcx, is)
+    [K"typed_hcat" t xs...] -> vst1_value(vcx, t) & allv(vst1_splat_or_val, vcx, xs)
+    [K"typed_vcat" t xs...] -> vst1_value(vcx, t) & allv(vst1_splat_or_val, vcx, xs)
+    [K"typed_ncat" t xs...] -> vst1_value(vcx, t) & allv(vst1_splat_or_val, vcx, xs)
+    [K"row" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    [K"nrow" xs...] -> allv(vst1_splat_or_val, vcx, xs)
+    _ -> false
+end
+
+# TODO: Are there things we can rule out from appearing in `...`?
+vst1_splat_or_val(vcx, st) = @stm st begin
+    [K"..." x] -> vst1_value(vcx, x)
+    [K"..." _...] -> fail("expected one argument to `...`")
+    _ -> vst1_value(vcx, st)
+end
+
+function vst1_generator(vcx, st)
+    vcx = with(vcx, :return_ok=>false, :toplevel=>false, :in_gscope=>false)
+    return @stm st begin
+        [K"generator" val its...] ->
+            vst1_value(vcx, val) &
+            allv(vst1_iterspec, vcx, its)
+        _ -> fail(vcx, st, "malformed `generator`")
+    end
+end
+
+vst1_iterspec(vcx, st) = @stm st begin
+    [K"filter" [K"iteration" is...] cond] -> allv(vst1_iter, vcx, is) & vst1_value(vcx, cond)
+    [K"iteration" is...] -> allv(vst1_iter, vcx, is)
+    _ -> fail(vcx, st, "malformed `iteration`")
+end
+
+vst1_iter(vcx, st) = @stm st begin
+    [K"in" [K"outer" i] v] -> vst1_assign_lhs(vcx, i) & vst1_value(vcx, v)
+    [K"in" i v] -> vst1_assign_lhs(vcx, i) & vst1_value(vcx, v)
+    _ -> fail(vcx, st, "malformed `in`")
+end
+
+"""
+For convenience, much of the validation code for st0 (non-macro-expanded trees) is
+shared with that for st1 (macro-expanded trees).  The main differences:
+- quote/unquote is valid in st0 but not st1
+- macrocalls are valid in st0 but not st1
+- any of the ad-hoc pre-desugaring we do in expand_forms_1
+
+Even though st0 should usually be limited to parser output, `valid_st0` allows a
+superset of `vst1_stmt` to allow for validation of partially-expanded trees.
+"""
+function valid_st0(st::SyntaxTree)
+    vcx = with(Validation1Context(), :unexpanded=>true)
+    valid = vst1_stmt(vcx, st)
+    for e in vcx.errors
+        showerror(stdout, LoweringError(e.sts[1], e.msg))
+        for st_ in e.sts[2:end]; show(st_); end
+        printstyled("---------------------------------\n"; color=:red)
+    end
+    return valid
+end
+valid_st0(vcx, st) = @stm st begin
+    _ -> vst1_stmt(vcx, st)
+end
+
+"""
+TODO: While we can't validate any arguments to a macrocall in general, it would
+make sense to check usage for things like @ccall.
+"""
+vst0_macrocall(vcx, st) = @stm st begin
+    [K"macrocall" name args...] -> vst0_macro_name(vcx, name)
+    _ -> false
+end
+
+vst0_quoted(vcx, st) = @stm st begin
+    ([K"$" x], when=vcx.quote_level===1) -> valid_st0(with(vcx, :quote_level=>0), x)
+    [K"quote"] -> vst0_quoted(with(vcx, :quote_level=>vcx.quote_level+1), st)
+    _ -> allv(vst0_quoted, vcx, children(st))
+end
+
+# Currently julia allows arbitrary top-level code in the first argument of a
+# macrocall.  It's probably OK to restrict this.
+vst0_macro_name(vcx, st) = @stm st begin
+    [K"." modpath [K"macro_name" mname]] -> (vst1_dotpath(vcx, modpath) & vst1_ident(vcx, mname))
+    [K"macro_name" [K"." modpath mname]] -> (vst1_dotpath(vcx, modpath) & vst1_ident(vcx, mname))
+    [K"Value"] -> true
+    _ -> fail(vcx, st, "invalid macro name")
+end
+
+# Non-lazy `&` to fetch errors from all subtrees in the iterable
+function allv(f, vcx, itr; kws...)
+    ok = true
+    for i in itr
+        ok &= f(vcx, i; kws...)
+    end
+    return ok
+end
+
+# `known` is true if validation passes or knows what's wrong; false otherwise.
+# Allows for a "match if `vst1_foo` knows what this is supposed to be" pattern:
+#
+#     (_, run=pass_or_err(vst1_foo, vcx, st), when=run.known) -> run.pass
+#
+# which is similar to splicing in all cases from `vst1_foo` that either pass or
+# produce an error (i.e. `_ -> false` cases are ignored).
+function pass_or_err(f, vcx, st; kws...)
+    n_err = length(vcx.errors)
+    pass = f(vcx, st; kws...)
+    known = pass || length(vcx.errors) > n_err
+    return (; known, pass)
+end
+
+function fail(vcx::Validation1Context, st::SyntaxTree, msg="invalid syntax")
+    if !vcx.speculative
+        push!(vcx.errors, ValidationDiagnostic(st, msg))
+    end
+    return false
+end
+
+vtodo(vcx, st, line=0) = (push!(vcx.errors, ValidationDiagnostic(st, "TODO: line $line")); false)

--- a/test/arrays_ir.jl
+++ b/test/arrays_ir.jl
@@ -34,7 +34,7 @@
 #---------------------
 LoweringError:
 [10, 20; 30]
-#      └──┘ ── unexpected semicolon in array expression
+#      └──┘ ── unexpected keyword-separating semicolon outside of call or tuple
 
 ########################################
 # Error: vect syntax with embedded assignments
@@ -390,7 +390,7 @@ a[i, j; w=1]
 #---------------------
 LoweringError:
 a[i, j; w=1]
-#     └───┘ ── unexpected semicolon in array expression
+#     └───┘ ── unexpected keyword-separating semicolon outside of call or tuple
 
 ########################################
 # simple setindex!

--- a/test/assignments_ir.jl
+++ b/test/assignments_ir.jl
@@ -169,7 +169,7 @@ a.(b) = rhs
 #---------------------
 LoweringError:
 a.(b) = rhs
-└───┘ ── invalid dot call syntax on left hand side of assignment
+└───┘ ── invalid `dotcall` on left side of assignment
 
 ########################################
 # Error: Invalid lhs in `=`
@@ -177,7 +177,7 @@ T[x y] = rhs
 #---------------------
 LoweringError:
 T[x y] = rhs
-└────┘ ── invalid spacing in left side of indexed assignment
+└────┘ ── invalid spacing on left side of indexed assignment
 
 ########################################
 # Error: Invalid lhs in `=`
@@ -233,7 +233,7 @@ LoweringError:
 #---------------------
 LoweringError:
 1 = rhs
-╙ ── invalid assignment location
+╙ ── invalid `Integer` on left side of assignment
 
 ########################################
 # Basic updating assignment
@@ -358,4 +358,4 @@ f() += y
 #---------------------
 LoweringError:
 (if false end, b) += 2
-└───────────────┘ ── invalid multiple assignment location
+#└──────────┘ ── invalid `if` on left side of assignment

--- a/test/branching_ir.jl
+++ b/test/branching_ir.jl
@@ -236,4 +236,4 @@ x = @label foo
 #---------------------
 LoweringError:
 x = @label foo
-#          └─┘ ── misplaced label in value position
+#          └─┘ ── misplaced `symbolic_label` in value position

--- a/test/decls_ir.jl
+++ b/test/decls_ir.jl
@@ -85,7 +85,7 @@ y = global x
 #---------------------
 LoweringError:
 y = global x
-#          ╙ ── global declaration doesn't read the variable and can't return a value
+#   └──────┘ ── global declaration doesn't read the variable and can't return a value
 
 ########################################
 # const
@@ -224,7 +224,7 @@ const local x = 1
 #---------------------
 LoweringError:
 const local x = 1
-└───────────────┘ ── unsupported `const local` declaration
+#    └──────────┘ ── locals cannot be declarated `const`
 
 ########################################
 # Error: Const not supported on locals
@@ -235,7 +235,7 @@ end
 LoweringError:
 let
     const x = 1
-#        └────┘ ── unsupported `const` declaration on local variable
+#   └─────────┘ ── unsupported `const` declaration on local variable
 end
 
 ########################################

--- a/test/destructuring_ir.jl
+++ b/test/destructuring_ir.jl
@@ -87,7 +87,7 @@ end
 #---------------------
 LoweringError:
 (xs..., ys...) = x
-#      └────┘ ── multiple `...` in destructuring assignment are ambiguous
+└────────────┘ ── multiple `...` in destructuring assignment are ambiguous
 
 ########################################
 # Recursive destructuring
@@ -376,7 +376,7 @@ end
 #---------------------
 LoweringError:
 (x ; a, b) = rhs
-└────────┘ ── Property destructuring must use a single `;` before the property names, eg `(; a, b) = rhs`
+# └─────┘ ── property destructuring must use a single `;` before the property names, eg `(; a, b) = rhs`
 
 ########################################
 # Error: Property destructuring with values for properties
@@ -384,4 +384,4 @@ LoweringError:
 #---------------------
 LoweringError:
 (; a=1, b) = rhs
-#  └─┘ ── invalid assignment location
+#  └─┘ ── expected identifier or `::`

--- a/test/function_calls_ir.jl
+++ b/test/function_calls_ir.jl
@@ -594,7 +594,7 @@ end
 #---------------------
 LoweringError:
 function A.ccall()
-#          └───┘ ── `(. a b)` requires symbol `b` after macro-expansion, or identifier before
+#          └───┘ ── this is a reserved identifier
 end
 
 ########################################

--- a/test/function_calls_ir.jl
+++ b/test/function_calls_ir.jl
@@ -559,7 +559,7 @@ cglobal = 10
 #---------------------
 LoweringError:
 cglobal = 10
-└─────┘ ── invalid assignment location
+└─────┘ ── invalid `core` on left side of assignment
 
 ########################################
 # Error: assigning to `ccall`
@@ -567,7 +567,7 @@ ccall = 10
 #---------------------
 LoweringError:
 ccall = 10
-└───┘ ── invalid assignment location
+└───┘ ── invalid `core` on left side of assignment
 
 ########################################
 # Error: assigning to `var"ccall"`
@@ -575,7 +575,7 @@ var"ccall" = 10
 #---------------------
 LoweringError:
 var"ccall" = 10
-#   └───┘ ── invalid assignment location
+#   └───┘ ── invalid `core` on left side of assignment
 
 ########################################
 # Error: Invalid function name ccall
@@ -584,7 +584,7 @@ end
 #---------------------
 LoweringError:
 function ccall()
-#        └───┘ ── Invalid function name
+#        └───┘ ── invalid function name
 end
 
 ########################################
@@ -594,7 +594,7 @@ end
 #---------------------
 LoweringError:
 function A.ccall()
-#        └─────┘ ── Invalid function name
+#          └───┘ ── `(. a b)` requires symbol `b` after macro-expansion, or identifier before
 end
 
 ########################################

--- a/test/function_calls_ir.jl
+++ b/test/function_calls_ir.jl
@@ -650,4 +650,4 @@ tuple(((xs...)...)...)
 #---------------------
 LoweringError:
 (xs...)
-#└───┘ ── `...` expression outside call
+#└───┘ ── unexpected splat not in `call`, `tuple`, `curly`, or array expression

--- a/test/functions_ir.jl
+++ b/test/functions_ir.jl
@@ -132,7 +132,7 @@ end
 #---------------------
 LoweringError:
 function f(xs..., y)
-#          └───┘ ── `...` may only be used for the last positional argument
+#          └───┘ ── `...` may only be used on the final parameter
     body
 end
 
@@ -390,7 +390,7 @@ end
 #---------------------
 LoweringError:
 function (.+)(x,y)
-#        └───────┘ ── Cannot define function using `.` broadcast syntax
+#        └───────┘ ── cannot define function using `.` broadcast syntax
 end
 
 ########################################
@@ -400,7 +400,7 @@ end
 #---------------------
 LoweringError:
 function f[](x,y)
-#        └─┘ ── Invalid function name
+#        └─┘ ── invalid function name
 end
 
 ########################################
@@ -746,7 +746,7 @@ end
 #---------------------
 LoweringError:
 function f(x=1, ys, z=2)
-#          └─┘ ── optional positional arguments must occur at end
+#               └┘ ── all function parameters after an optional parameter must also be optional
     ys
 end
 
@@ -1469,7 +1469,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_destruct(; (x,y)=10)
-#                        └───┘ ── Invalid keyword name
+#                        └───┘ ── expected identifier or `::`
 end
 
 ########################################
@@ -1479,7 +1479,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_slurp_default(; kws...=def)
-#                             └────────┘ ── keyword argument with `...` cannot have a default value
+#                             └────┘ ── expected identifier or `::`
 end
 
 ########################################
@@ -1499,7 +1499,7 @@ end
 #---------------------
 LoweringError:
 function f_kw_slurp_not_last(; kws..., x=1)
-#                              └────┘ ── `...` may only be used for the last keyword argument
+#                              └────┘ ── `...` may only be used for the last keyword parameter
 end
 
 ########################################

--- a/test/generators_ir.jl
+++ b/test/generators_ir.jl
@@ -128,9 +128,9 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#->##5 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#->##4 %₁ %₂)
 4   latestworld
-5   TestMod.#->##5
+5   TestMod.#->##4
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:2
@@ -150,7 +150,7 @@ LoweringError:
     11  TestMod.body
     12  (return %₁₁)
 11  latestworld
-12  TestMod.#->##5
+12  TestMod.#->##4
 13  (new %₁₂)
 14  TestMod.iter
 15  (call top.Generator %₁₃ %₁₄)
@@ -162,9 +162,9 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#->##6 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#->##5 %₁ %₂)
 4   latestworld
-5   TestMod.#->##6
+5   TestMod.#->##5
 6   (call core.svec %₅ core.Any)
 7   (call core.svec)
 8   SourceLocation::1:4
@@ -174,7 +174,7 @@ LoweringError:
     1   (call JuliaLowering.interpolate_ast SyntaxTree (inert (return x)))
     2   (return %₁)
 11  latestworld
-12  TestMod.#->##6
+12  TestMod.#->##5
 13  (new %₁₂)
 14  TestMod.iter
 15  (call top.Generator %₁₃ %₁₄)
@@ -194,7 +194,7 @@ LoweringError:
 #---------------------
 1   (call core.svec)
 2   (call core.svec)
-3   (call JuliaLowering.eval_closure_type TestMod :#->##7 %₁ %₂)
+3   (call JuliaLowering.eval_closure_type TestMod :#->##6 %₁ %₂)
 4   latestworld
 5   (call core.svec)
 6   (call core.svec)
@@ -212,7 +212,7 @@ LoweringError:
     3   slot₃/x
     4   (return %₃)
 15  latestworld
-16  TestMod.#->##7
+16  TestMod.#->##6
 17  (call core.svec %₁₆ core.Any)
 18  (call core.svec)
 19  SourceLocation::1:2
@@ -226,7 +226,7 @@ LoweringError:
     5   (call top.Generator %₂ %₄)
     6   (return %₅)
 22  latestworld
-23  TestMod.#->##7
+23  TestMod.#->##6
 24  (new %₂₃)
 25  TestMod.:
 26  (call %₂₅ 1 3)

--- a/test/loops_ir.jl
+++ b/test/loops_ir.jl
@@ -119,7 +119,7 @@ break
 #---------------------
 LoweringError:
 break
-└───┘ ── break must be used inside a `while` or `for` loop
+└───┘ ── `break` must be used inside a `while` or `for` loop
 
 ########################################
 # Error: continue outside for/while
@@ -127,7 +127,7 @@ continue
 #---------------------
 LoweringError:
 continue
-└──────┘ ── continue must be used inside a `while` or `for` loop
+└──────┘ ── `continue` must be used inside a `while` or `for` loop
 
 ########################################
 # Error: `outer` without outer local variable

--- a/test/macros_ir.jl
+++ b/test/macros_ir.jl
@@ -123,7 +123,7 @@ let
 #   ┌────────────
     macro foo(ex)
     end
-#─────┘ ── macro is only allowed in global scope
+#─────┘ ── macro definition is not allowed in a local scope
 end
 
 ########################################
@@ -138,7 +138,7 @@ function f()
 #   ┌──────────
     macro foo()
     end
-#─────┘ ── macro is only allowed in global scope
+#─────┘ ── macro definition is not allowed in a local scope
 end
 
 ########################################

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -148,7 +148,7 @@ LoweringError:
 #---------------------
 LoweringError:
 (a=1; b=2, c=3)
-#   └────────┘ ── unexpected semicolon in tuple - use `,` to separate tuple elements
+#   └────────┘ ── cannot mix tuple `(a,b,c)` and named tuple `(;a,b,c)` syntax
 
 ########################################
 # Error: Named tuple field dots in rhs

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -227,7 +227,7 @@ x::T
 #---------------------
 LoweringError:
 ::T
-└─┘ ── invalid syntax: unknown kind `::` or number of arguments (1)
+└─┘ ── `::` must be written `value::type` outside function argument lists
 
 ########################################
 # Error: braces vector syntax

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -34,7 +34,7 @@ x."b"
 @ast_ [K"." "x"::K"Identifier" "a"::K"Identifier" 3::K"Integer"]
 #---------------------
 LoweringError:
-#= line 1 =# - `.` form requires either one or two children
+#= line 1 =# - invalid syntax: unknown kind `.` or number of arguments (3)
 
 ########################################
 # Error: Placeholder value used
@@ -156,7 +156,7 @@ LoweringError:
 #---------------------
 LoweringError:
 (; a=xs...)
-#    └───┘ ── `...` cannot be used in a value for a named tuple field
+#    └───┘ ── unexpected splat not in `call`, `tuple`, `curly`, or array expression
 
 ########################################
 # Error: Named tuple field invalid lhs
@@ -164,7 +164,7 @@ LoweringError:
 #---------------------
 LoweringError:
 (; a[]=1)
-#  └─┘ ── invalid named tuple field name
+#  └─┘ ── expected identifier, got `ref`
 
 ########################################
 # Error: Named tuple element with weird dot syntax
@@ -209,7 +209,7 @@ function f()
 #   ┌───────
     module C
     end
-#─────┘ ── `module` is only allowed at top level
+#─────┘ ── this syntax is only allowed in top level code
 end
 
 ########################################
@@ -227,7 +227,7 @@ x::T
 #---------------------
 LoweringError:
 ::T
-└─┘ ── `::` must be written `value::type` outside function argument lists
+└─┘ ── invalid syntax: unknown kind `::` or number of arguments (1)
 
 ########################################
 # Error: braces vector syntax
@@ -235,7 +235,7 @@ LoweringError:
 #---------------------
 LoweringError:
 {x, y}
-└────┘ ── { } syntax is reserved for future use
+└────┘ ── `braces` outside of `where` is reserved for future use
 
 ########################################
 # Error: braces matrix syntax
@@ -243,7 +243,7 @@ LoweringError:
 #---------------------
 LoweringError:
 {x y; y z}
-└────────┘ ── { } syntax is reserved for future use
+└────────┘ ── `bracescat` is reserved for future use
 
 ########################################
 # Error: Test AST which has no source form and thus must have been constructed
@@ -251,7 +251,7 @@ LoweringError:
 @ast_ [K"if"]
 #---------------------
 LoweringError:
-#= line 1 =# - expected `numchildren(ex) >= 2`
+#= line 1 =# - invalid syntax: unknown kind `if` or number of arguments (0)
 
 ########################################
 # Error: @atomic in wrong position
@@ -262,7 +262,7 @@ end
 LoweringError:
 let
     @atomic x
-#   └───────┘ ── unimplemented or unsupported atomic declaration
+#   └───────┘ ── unimplemented or unsupported `atomic` declaration
 end
 
 ########################################
@@ -486,7 +486,7 @@ MacroExpansionError while expanding @ccall in module Main.TestMod:
 #---------------------
 LoweringError:
 &x
-└┘ ── invalid syntax
+└┘ ── invalid syntax: unknown kind `&` or number of arguments (1)
 
 ########################################
 # Error: $ outside quote/string
@@ -494,7 +494,7 @@ $x
 #---------------------
 LoweringError:
 $x
-└┘ ── `$` expression outside string or quote block
+└┘ ── `$` expression outside string or quote
 
 ########################################
 # Error: splat outside call
@@ -502,7 +502,7 @@ x...
 #---------------------
 LoweringError:
 x...
-└──┘ ── `...` expression outside call
+└──┘ ── unexpected splat not in `call`, `tuple`, `curly`, or array expression
 
 ########################################
 # `include` should increment world age

--- a/test/quoting_ir.jl
+++ b/test/quoting_ir.jl
@@ -40,5 +40,5 @@ end
 LoweringError:
 quote
     $$x + 1
-#    └┘ ── `$` expression outside string or quote block
+#    └┘ ── `$` expression outside string or quote
 end

--- a/test/typedefs_ir.jl
+++ b/test/typedefs_ir.jl
@@ -92,7 +92,7 @@ A where X < Y < Z
 #---------------------
 LoweringError:
 A where X < Y < Z
-#       └───────┘ ── invalid type bounds
+#       └───────┘ ── expected `lb <: type_name <: ub` or `ub >: type_name >: lb`
 
 ########################################
 # Error: bad type bounds
@@ -100,7 +100,7 @@ A where X <: f() <: Z
 #---------------------
 LoweringError:
 A where X <: f() <: Z
-#            └─┘ ── expected type name
+#       └───────────┘ ── expected `lb <: type_name <: ub` or `ub >: type_name >: lb`
 
 ########################################
 # Error: bad type bounds
@@ -173,7 +173,7 @@ X{S, T; W}
 #---------------------
 LoweringError:
 X{S, T; W}
-#     └─┘ ── unexpected semicolon in type parameter list
+#     └─┘ ── unexpected keyword-separating semicolon outside of call or tuple
 
 ########################################
 # Error: assignment in type application
@@ -269,7 +269,7 @@ abstract type A(){T} end
 #---------------------
 LoweringError:
 abstract type A(){T} end
-#             └────┘ ── invalid type signature
+#             └─┘ ── expected identifier, got `call`
 
 ########################################
 # Error: Abstract type definition with bad signature
@@ -277,7 +277,7 @@ abstract type A() <: B end
 #---------------------
 LoweringError:
 abstract type A() <: B end
-#            └───────┘ ── invalid type signature
+#             └─┘ ── expected identifier, got `call`
 
 ########################################
 # Error: Abstract type definition in function scope


### PR DESCRIPTION
Desugaring is massive: in both flisp and JuliaLowering, it is larger in bytes
than all other lowering passes combined.  Being the first pass after parsing and
macro-expansion, it's also the judge of whether or not an AST is structurally
valid, causing all sorts of issues:

1. It isn't readable despite it being the de-facto specification of the
   lowerable AST.  Combining this with any incompleteness or outdatedness in the
   AST developer documentation, macro authors are left to guess what inputs
   they'll see and outputs they can produce.

2. Desugaring is responsible for both checking input and transforming it.  This
   is because macros can produce anything, and parsing produces a superset of
   lowering-recognized ASTs anyway.  The checking here is especially unwanted
   given that much of desugaring's input is output from other desugaring
   functions (related to (4) below), which shouldn't go through the same level of
   checking as arbitrary user input.

3. Desugaring is limited in its capacity to produce errors.  It won't detect
   multiple errors per pass, and doesn't point at more than one tree per error.
   There's no reason it *can't*, but the benefit of upgraded errors isn't
   clearly worth adding even more desugaring complexity.

4. How each expression gets through desugaring is generally unknown.  In both
   implementations, we often take a sledgehammer approach:

   ```julia
   # flisp: (expand-forms (expand-foo foo))

   ex = expand_foo(ctx, foo) # we know we need to desugar away foo...
   expand_forms_2(ctx, ex)   # ...but some form we introduced needs more
                             # desugaring, and we don't know which one
   ```
   where it isn't clear if desugaring will terminate.  (There have been cases
   where it hasn't: https://github.com/JuliaLang/julia/issues/51572, https://github.com/JuliaLang/julia/issues/57733)

5. Likely due to (1) making this difficult to even plan to implement, syntax
   evolution at the AST level is unimplemented.

## This PR

The goal of this PR is to fix issues 1-3 and allow us to address issues 4 and 5
over time by pulling desugaring's "define and check the AST" responsibility into
a separate pass.

The new `valid_st1([vcx::Validation1Context] st::SyntaxTree)::Bool` function
check that `st` is a structurally valid input to lowering/output of macro
expansion.  It and its callees serve three main purposes:
1. A readable reference for the julia AST structure
2. A set of assumptions we can use in lowering so we can simplify desugaring
   over time.  Desugaring that assumes its input has passed `valid_st1` can
   focus on transformations instead of checking what it has at every step.
3. The producer of useful user-facing errors for bad macro (or parser) output.

`valid_st1` is complete enough to pass all JuliaLowering tests, and I've set it
up to run right before desugaring.  Some error messages have changed (some a bit
better, others a bit worse).  We can work on more helpful errors over time.

`valid_st0` is also provided (nearly the same AST, but quotes and macros are
unexpanded).  This is also necessary as a callee of `valid_st1` since embedded
`module` and `toplevel` in a macro-expanded expression should not be expanded.

These functions only check the JuliaSyntax/JuliaLowering-produced AST, which is
different from the Expr AST, but only by rearranging Expr in a few well-defined
cases.  If we wanted a version checking the Expr AST, most of the current
version of validation.jl could be taken and used.

### `@stm` "syntax tree match"

This PR also contains a `SyntaxTree` pattern-matching macro, inspired by [racket
`match`](https://docs.racket-lang.org/reference/match.html), but much simpler.

This is to keep validation functions grammar-like, and to keep the amount of
validation code manageable.  Much more detail is available in the docstring.

This macro is arguably even better for post-validation desugaring since the
structure of its inputs are known.

Here's an example of a desugaring helper we could refactor:

```julia
# Match `x<:T<:y` etc, returning `(name, lower_bound, upper_bound)`
# A bound is `nothing` if not specified
function analyze_typevar(ctx, ex)
    k = kind(ex)
    if k == K"Identifier"
        (ex, nothing, nothing)
    elseif k == K"comparison" && numchildren(ex) == 5
        kind(ex[3]) == K"Identifier" || throw(LoweringError(ex[3], "expected type name"))
        if !((kind(ex[2]) == K"Identifier" && ex[2].name_val == "<:") &&
             (kind(ex[4]) == K"Identifier" && ex[4].name_val == "<:"))
            throw(LoweringError(ex, "invalid type bounds"))
        end
        # a <: b <: c
        (ex[3], ex[1], ex[5])
    elseif k == K"<:" && numchildren(ex) == 2
        kind(ex[1]) == K"Identifier" || throw(LoweringError(ex[1], "expected type name"))
        (ex[1], nothing, ex[2])
    elseif k == K">:" && numchildren(ex) == 2
        kind(ex[2]) == K"Identifier" || throw(LoweringError(ex[2], "expected type name"))
        (ex[1], ex[2], nothing)
    else
        throw(LoweringError(ex, "expected type name or type bounds"))
    end
end
```

Assuming the AST is valid, we can reduce this to the following.  Note that
adding the comparison case with ">:" is a bugfix.

```julia
analyze_typevar_refactored(ctx, ex) = @stm st begin
    [K"Identifier"] -> (ex, nothing, nothing)
    ([K"comparison" lb op t _ ub], when=op.name_val==="<:") -> (t, lb, ub)
    ([K"comparison" ub op t _ lb], when=op.name_val===">:") -> (t, lb, ub)
    [K"<:" t ub] -> (t, nothing, ub)
    [K">:" t lb] -> (t, lb, nothing)
end
```

For the curious, the relevant validation function looks something like:

```julia
vst1_typevar_decl(vcx, st) = @stm st begin
    [K"Identifier"] -> true
    [K"<:" [K"Identifier"] old] -> vst1_value(vcx, old)
    [K">:" [K"Identifier"] old] -> vst1_value(vcx, old)
    ([K"comparison" old1 [K"Identifier"] [K"Identifier"] [K"Identifier"] old2],
     when=st[2].name_val===st[4].name_val && st[2].name_val in ("<:", ">:")) ->
         vst1_value(vcx, old1) & vst1_value(vcx, old2)

    [K"<:" x _] -> fail(vcx, x, "expected type name")
    [K">:" x _] -> fail(vcx, x, "expected type name")
    [K"comparison" _...] -> fail(vcx, st, "expected `lb <: type_name <: ub` or `ub >: type_name >: lb`")
    _ -> fail(vcx, st, "expected type name or type bounds")
end
```

### RFC: Interaction with "strict mode"
If I understand the discussions on a potential [strict mode](https://github.com/JuliaLang/julia/issues/54903) correctly, this PR solves
a different problem.  Strict mode would disallow specific inputs that can
produce undesirable behaviour (but not undesirable to enough people to be
completely disallowed).  This PR aims to define the AST-space that strict mode
operates in.

This is still somewhat related to strict mode since `valid_st1` would be the
easiest place to pass in options and enforce any AST-related rules.  However, I
think we should avoid this for now given our improved grip on the AST structure.
Can we instead take all questionable or ambiguous syntax and disallow it in a
future AST version instead?  See the section below.

### RFC: Syntax evolution
I'd like to make non-macro-breaking AST evolution possible.  I suggest we have
validation.jl serve as the specification of an AST version and write a pass
transforming each AST of version `n` to version `n+1`, which runs after
expanding macros that expect an older AST.  This assumes a syntax version is
defined at the project level and tied to a major version with no mixtures of
macros expecting different AST versions. We may want something more complex.

Note that many discussions on "syntax evolution" are about changes in parsing,
which would need a separate versioning mechanism.  Maybe each parser version
targets one AST version, and the user-facing syntax version is just the parser
version?

Rust's editions are usually mentioned here. I'm not familiar with this
mechanism, but I know it's well-regarded and that I should do some research here
before making any more suggestions.

## Potential next steps
- There are many places the AST can be improved (see #77 for some).  We don't
  need AST evolution as described above until macros start taking SyntaxTree, so
  now is the time to break and improve things.
- Not urgent, but we can start simplifying desugaring based on the invariants we
  get from validation
- (Probably after JuliaLowering has moved to the julia repo) Set up a pkgeval
  that runs all code through `valid_st1` before flisp lowering to make sure
  `valid_st1` actually allows all syntax we plan to support.  I'm prepared to
  add nasty we-should-have-never-allowed-this cases here.
- It's definitely more important to have a definition/validator for the IR, but a
  few practical reasons made me wait:
  - There is no easy way to get "reference" IR in SyntaxTree form; we would need
    to either live without pattern matching, or flisp-lower and write
    Expr->SyntaxTree for lowered code.
  - We already have some amount of IR validation in Base
  - I know less about what constitutes valid IR
- Write a fuzzer based on the AST description

## Misc

### Why now?

I think writing down our input language will help us achieve compatibility with
existing code.  We'll likely see some crazy broken syntax in our long tail of
testing.  Validation will let us properly disallow it with a useful error,
provide a place to write weird syntax down if we plan to support it, and
hopefully (through syntax evolution) let us disallow it in future versions.

### Alternative approach

I considered an alternative `valid_st1` that isn't responsible for generating
nice user-facing errors, which can simply return a boolean and describe errors
if it's easy to do so.  This approach could keep `valid_st1` simpler and more
grammar-like---we can just describe the set of valid ASTs, return false eagerly
on error, and not waste bytes figuring out or reporting what exactly went wrong.
This would be optimal for a human-readable specification.  However, bytes not
wasted on disambiguating and describing errors still need to exist in the first
lowering pass, and we wouldn't get most of the benefits of this PR.

Still, I'd like to keep the main part of each validation function free of
error-determination code to keep it more like a grammar, even if it means
redoing some work in the error case.  This is so someone using it as a reference
can immediately see what's allowed, and doesn't need to read it top-to-bottom.
I haven't succeeded in all cases.