### PR TITLE
`expr_to_syntaxtree`: don't fail when incoming expr is invalid

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -133,6 +133,11 @@ function _register_kinds()
             "constdecl"
             # Returned from statements that should error if the result is used.
             "unused_only"
+            # Leaf kind denoting unquoted AST where `.value` is an Expr. Only
+            # used for compatibility with old-style macros called with arguments
+            # that have no other representation in SyntaxTree (e.g. head mapping
+            # to no kind, interpolations in strange places, etc).
+            "expr_syntax"
         "END_LOWERING_KINDS"
 
         # The following kinds are emitted by lowering and used in Julia's untyped IR

--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -517,6 +517,10 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
                 (expand_forms_1(ctx, a) for a in args)...
             ]
         end
+    elseif k === K"expr_syntax"
+        throw(LoweringError(ex, "malformed Expr outside of macrocall or quote: \
+              check for macros producing unlowerable forms, \
+              or missing cases in `expr_to_syntaxtree`"))
     elseif is_leaf(ex)
         ex
     elseif k == K"<:" || k == K">:" || k == K"-->"

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -360,6 +360,19 @@ end
     """; expr_compat_mode=true)
     @test test_mod.SOME_ENUM <: Enum
     @test test_mod.X1 isa Enum
+
+    # Completely unknown expr heads are OK to produce from macro expansions as
+    # long as another macro cleans it up
+    Base.include_string(test_mod, """
+    macro unbungle(x)
+        :(1)
+    end
+
+    macro bungle()
+        esc(Expr(:macrocall, :var"@unbungle", @__LINE__, Expr(Symbol("what???"), 1, 2, 3)))
+    end""")
+
+    @test JuliaLowering.include_string(test_mod, "@bungle()"; expr_compat_mode=true) === 1
 end
 
 @testset "macros producing meta forms" begin


### PR DESCRIPTION
Currently, we have a pile of assertions in `expr_to_syntaxtree` checking the
validity of the given Expr.  This means JuliaLowering can't handle old macros
calling old or new macros with unrecognized Expr forms---in the "old calling
old" case, this is breakage, and in the "old calling new" case it's still a
downgrade to the macro system.  `expr_to_syntaxtree` handles macro input and
quoted expressions, so it can't assume anything about the AST structure.

This PR attempts to define `expr_to_syntaxtree` on all inputs in a sane way.
1. If `e` is one of the known forms with a different representation in
   SyntaxTree, convert it.
2. Otherwise, if `e.head` corresponds to a known `JuliaSyntax.Kind`, insert that
   and recurse on its children.
3. Otherwise, insert an `K"expr_syntax"` node with `e` as its `.value`.  We'll
   still get an error as we did before if we try and evaluate this, but a future
   expansion is expected to clean it up.

The assertions have been removed, but their contents are generally kept for
deciding between cases (1) and (2) above.