### PR TITLE
Implement `@ eval` macro for SyntaxTree

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -165,7 +165,7 @@ function _register_kinds()
             "new_opaque_closure"
             # Wrapper for the lambda of around opaque closure methods
             "opaque_closure_method"
-            # World age increment
+            # World age increment (TODO: use top level assertion and only one latestworld kind)
             "latestworld"
         "END_IR_KINDS"
     ])

--- a/src/syntax_macros.jl
+++ b/src/syntax_macros.jl
@@ -272,6 +272,33 @@ function Base.Experimental.var"@opaque"(__context__::MacroContext, ex)
     ]
 end
 
+function _at_eval_code(ctx, srcref, mod, ex)
+    @ast ctx srcref [K"block"
+        [K"local"
+            [K"="
+                "eval_result"::K"Identifier"
+                [K"call"
+                    # TODO: Call "eval"::K"core" here
+                    JuliaLowering.eval::K"Value"
+                    mod
+                    [K"quote" ex]
+                ]
+            ]
+        ]
+        (::K"latestworld_if_toplevel")
+        "eval_result"::K"Identifier"
+    ]
+end
+
+function Base.var"@eval"(__context__::MacroContext, ex)
+    mod = @ast __context__ __context__.macrocall __context__.scope_layer.mod::K"Value"
+    _at_eval_code(__context__, __context__.macrocall, mod, ex)
+end
+
+function Base.var"@eval"(__context__::MacroContext, mod, ex)
+    _at_eval_code(__context__, __context__.macrocall, mod, ex)
+end
+
 #--------------------------------------------------------------------------------
 # The following `@islocal` and `@inert` are macros for special syntax known to
 # lowering which don't exist in Base but arguably should.

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -20,6 +20,23 @@ let x = [1,2]
 end
 """) == [1,2]
 
+@test JuliaLowering.include_string(test_mod, raw"""
+let
+    x = 10
+    @eval $x + 2
+end
+""") == 12
+
+@test JuliaLowering.include_string(test_mod, raw"""
+module EvalTest
+    _some_var = 2
+end
+let
+    x = 10
+    @eval EvalTest $x + _some_var
+end
+""") == 12
+
 @test JuliaLowering.include_string(test_mod, """
 let x=11
     20x

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -295,6 +295,31 @@ GC.@preserve a b g() begin
 end
 
 ########################################
+# @eval without module
+@eval $f(x, y)
+#---------------------
+1   TestMod.f
+2   (call core.tuple %₁)
+3   (call JuliaLowering.interpolate_ast SyntaxTree (inert (call ($ f) x y)) %₂)
+4   (= slot₁/eval_result (call JuliaLowering.eval TestMod %₃))
+5   latestworld
+6   slot₁/eval_result
+7   (return %₆)
+
+########################################
+# @eval with module
+@eval mod $f(x, y)
+#---------------------
+1   TestMod.mod
+2   TestMod.f
+3   (call core.tuple %₂)
+4   (call JuliaLowering.interpolate_ast SyntaxTree (inert (call ($ f) x y)) %₃)
+5   (= slot₁/eval_result (call JuliaLowering.eval %₁ %₄))
+6   latestworld
+7   slot₁/eval_result
+8   (return %₇)
+
+########################################
 # Juxtaposition
 20x
 #---------------------


### PR DESCRIPTION
I thought I needed `@eval` for something else but it turned out to be unnecessary.

We may as well have it, however :)