### PR TITLE
Use relative import paths in tests

### DIFF
--- a/test/branching.jl
+++ b/test/branching.jl
@@ -4,11 +4,6 @@
 
 test_mod = Module()
 
-Base.eval(test_mod, quote
-    using JuliaLowering: JuliaLowering, @ast, @chk
-    using JuliaSyntax
-end)
-
 #-------------------------------------------------------------------------------
 @testset "Tail position" begin
 

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -1,6 +1,4 @@
 using Test
-using JuliaSyntax
-using JuliaLowering
 const JS = JuliaSyntax
 const JL = JuliaLowering
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -4,10 +4,15 @@ test_mod = Module(:macro_test)
 Base.eval(test_mod, :(const var"@ast" = $(JuliaLowering.var"@ast")))
 Base.eval(test_mod, :(const var"@K_str" = $(JuliaLowering.var"@K_str")))
 
+# These libraries may either be packages or vendored into Base - need to pull
+# them in via relative paths in the `using` statements below.
+Base.eval(test_mod, :(const JuliaLowering = $(JuliaLowering)))
+Base.eval(test_mod, :(const JuliaSyntax = $(JuliaSyntax)))
+
 JuliaLowering.include_string(test_mod, raw"""
 module M
-    using JuliaLowering: JuliaLowering, @ast, @chk, adopt_scope
-    using JuliaSyntax
+    using ..JuliaLowering: JuliaLowering, adopt_scope
+    using ..JuliaSyntax
 
     # Introspection
     macro __MODULE__()

--- a/test/repl_mode.jl
+++ b/test/repl_mode.jl
@@ -1,3 +1,6 @@
+# JuliaLowering REPL mode: an interactive test utility for lowering code (not
+# part of the unit tests)
+
 module JuliaLoweringREPL
 
 import ReplMaker

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-using Test
-
 include("utils.jl")
 
 @testset "JuliaLowering.jl" begin

--- a/test/scopes_ir.jl
+++ b/test/scopes_ir.jl
@@ -1,4 +1,4 @@
-using JuliaLowering: @islocal
+using .JuliaLowering: @islocal
 using Base: @locals
 
 #*******************************************************************************

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,9 @@
+# Shared testing code which should be included before running individual test files.
 using Test
 
 using JuliaLowering
 using JuliaSyntax
+
 import FileWatching
 
 # The following are for docstrings testing. We need to load the REPL module
@@ -10,9 +12,9 @@ import FileWatching
 using Markdown
 import REPL
 
-using JuliaSyntax: sourcetext, set_numeric_flags
+using .JuliaSyntax: sourcetext, set_numeric_flags
 
-using JuliaLowering:
+using .JuliaLowering:
     SyntaxGraph, newnode!, ensure_attributes!,
     Kind, SourceRef, SyntaxTree, NodeId,
     makenode, makeleaf, setattr!, sethead!,
@@ -153,8 +155,9 @@ end
 
 function setup_ir_test_module(preamble)
     test_mod = Module(:TestMod)
-    JuliaLowering.include_string(test_mod, preamble)
+    Base.eval(test_mod, :(const JuliaLowering = $JuliaLowering))
     Base.eval(test_mod, :(const var"@ast_" = $(var"@ast_")))
+    JuliaLowering.include_string(test_mod, preamble)
     test_mod
 end
 


### PR DESCRIPTION
For vendoring into Base we need to avoid absolute import paths as in
`using JuliaLowering` and `using JuliaSyntax` in the test files as
neither of these packages will be top level modules. Thus, replace all
occurrences of these with relative import paths except for one central
location (currently in util.jl) which can be easily adjusted.

~~Currently based on #109~~