### PR TITLE
Fix `@nospecialize` with zero args

### DIFF
--- a/test/macros_ir.jl
+++ b/test/macros_ir.jl
@@ -186,3 +186,25 @@ cmdmac`hello`
 cmdmac`hello`12345
 #---------------------
 1   (return "hello from cmdmac with suffix 12345")
+
+########################################
+# @nospecialize (zero args)
+function foo()
+    @nospecialize
+end
+#---------------------
+1   (method TestMod.foo)
+2   latestworld
+3   TestMod.foo
+4   (call core.Typeof %₃)
+5   (call core.svec %₄)
+6   (call core.svec)
+7   SourceLocation::1:10
+8   (call core.svec %₅ %₆ %₇)
+9   --- method core.nothing %₈
+    slots: [slot₁/#self#(!read)]
+    1   (meta :nospecialize)
+    2   (return core.nothing)
+10  latestworld
+11  TestMod.foo
+12  (return %₁₁)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -114,7 +114,10 @@ function uncomment_description(desc)
 end
 
 function comment_description(desc)
-    replace(desc, r"^"m=>"# ")
+    lines = replace(split(desc, '\n')) do line
+        strip("# " * line)
+    end
+    join(lines, '\n')
 end
 
 function match_ir_test_case(case_str)
@@ -231,7 +234,7 @@ function refresh_ir_test_cases(filename, pattern=nothing)
         else
             ir = case.output
         end
-        println(io,
+        (case == cases[end] ? print : println)(io,
             """
             ########################################
             $(comment_description(case.description))


### PR DESCRIPTION
On top of #103.  Also fix IR test case refresh script introducing extra whitespace.