### PR TITLE
Macro expansion: only hygienic-scope-wrap `toplevel` if unescaped

### DIFF
--- a/src/macro_expansion.jl
+++ b/src/macro_expansion.jl
@@ -328,7 +328,6 @@ function expand_macro(ctx, ex)
         # method was defined (may be different from `parentmodule(macfunc)`)
         mod_for_ast = lookup_method_instance(macfunc, macro_args,
                                              ctx.macro_world).def.module
-        expanded = fix_toplevel_expansion(ctx, expanded, mod_for_ast, macro_loc)
         new_layer = ScopeLayer(length(ctx.scope_layers)+1, mod_for_ast,
                                current_layer_id(ctx), true)
         push_layer!(ctx, mod_for_ast, true)
@@ -448,6 +447,9 @@ function expand_forms_1(ctx::MacroExpansionContext, ex::SyntaxTree)
         end
     elseif k == K"macrocall"
         expand_macro(ctx, ex)
+    elseif k == K"toplevel" && length(ctx.scope_layer_stack) > 1
+        fix_toplevel_expansion(ctx, ex, current_layer(ctx).mod,
+                               source_location(LineNumberNode, ex))
     elseif k == K"module" || k == K"toplevel" || k == K"inert"
         # Remove scope layer information from any inert syntax which survives
         # macro expansion so that it doesn't contaminate lowering passes which


### PR DESCRIPTION
I didn't originally implement this correctly: toplevel forms coming from macro expansions only need tweaking if we're in some scope layer other than the default one.

Draft because I need to merge other fixes before my test case runs:
```
@doc "foo" @enum(ENUM, ENUM_A=0, ENUM_B=1)
```