### PR TITLE
Fix "Fix `ccall` with no supplied varargs"

### DIFF
--- a/test/function_calls_ir.jl
+++ b/test/function_calls_ir.jl
@@ -406,14 +406,15 @@ ccall(:printf, Cint, (Cstring, Cstring...), "%s = %s\n", "2 + 2", "5")
 #---------------------
 1   TestMod.Cstring
 2   TestMod.Cstring
-3   (call top.cconvert %₁ "%s = %s\n")
-4   (call top.cconvert %₂ "2 + 2")
-5   (call top.cconvert %₂ "5")
-6   (call top.unsafe_convert %₁ %₃)
-7   (call top.unsafe_convert %₂ %₄)
+3   TestMod.Cstring
+4   (call top.cconvert %₁ "%s = %s\n")
+5   (call top.cconvert %₂ "2 + 2")
+6   (call top.cconvert %₃ "5")
+7   (call top.unsafe_convert %₁ %₄)
 8   (call top.unsafe_convert %₂ %₅)
-9   (foreigncall :printf (static_eval TestMod.Cint) (static_eval (call core.svec TestMod.Cstring TestMod.Cstring TestMod.Cstring)) 1 :ccall %₆ %₇ %₈ %₃ %₄ %₅)
-10  (return %₉)
+9   (call top.unsafe_convert %₃ %₆)
+10  (foreigncall :printf (static_eval TestMod.Cint) (static_eval (call core.svec TestMod.Cstring TestMod.Cstring TestMod.Cstring)) 1 :ccall %₇ %₈ %₉ %₄ %₅ %₆)
+11  (return %₁₀)
 
 ########################################
 # Error: ccall with too few arguments

--- a/test/misc_ir.jl
+++ b/test/misc_ir.jl
@@ -455,15 +455,14 @@ ccall(:fcntl, Cint, (RawFD, Cint, Cint...), s, F_GETFL)
 #---------------------
 1   TestMod.RawFD
 2   TestMod.Cint
-3   TestMod.Cint
-4   TestMod.s
-5   (call top.cconvert %₁ %₄)
-6   TestMod.F_GETFL
-7   (call top.cconvert %₂ %₆)
-8   (call top.unsafe_convert %₁ %₅)
-9   (call top.unsafe_convert %₂ %₇)
-10  (foreigncall :fcntl (static_eval TestMod.Cint) (static_eval (call core.svec TestMod.RawFD TestMod.Cint TestMod.Cint)) 2 :ccall %₈ %₉ %₅ %₇)
-11  (return %₁₀)
+3   TestMod.s
+4   (call top.cconvert %₁ %₃)
+5   TestMod.F_GETFL
+6   (call top.cconvert %₂ %₅)
+7   (call top.unsafe_convert %₁ %₄)
+8   (call top.unsafe_convert %₂ %₆)
+9   (foreigncall :fcntl (static_eval TestMod.Cint) (static_eval (call core.svec TestMod.RawFD TestMod.Cint)) 2 :ccall %₇ %₈ %₄ %₆)
+10  (return %₉)
 
 ########################################
 # Error: No return annotation on @ccall


### PR DESCRIPTION
#102 fixed the error in lowering, but I neglected the fact we were still pushing the extra vararg type, so the IR was bad.  Real tests included this time (from julia's test/ccall.jl).